### PR TITLE
Add System.Text.Json support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,3 +26,6 @@ dotnet_diagnostic.CA1054.severity = none
 
 # CA1051: Do not declare visible instance fields
 dotnet_diagnostic.CA1051.severity = none
+
+# Tab indentation
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ node_modules
 /fetchapi/coverage
 /jq/_reports
 /Tests/NG2TestBed/src/clientapi/ClientApiAuto.ts
+/Tests/openapi-directory

--- a/Fonlow.OpenApiClientGen.ClientTypes/ComponentsHelper.cs
+++ b/Fonlow.OpenApiClientGen.ClientTypes/ComponentsHelper.cs
@@ -61,14 +61,26 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 			return ns.FindTypeDeclaration(typeName);
 		}
 
-		public static CodeTypeReference CreateArrayOfCustomTypeReference(string typeName, int arrayRank)
+		public static CodeTypeReference CreateArrayOfCustomTypeReference(string typeName, int arrayRank, Settings settings = null)
 		{
-			CodeTypeReference elementTypeReference = new CodeTypeReference(typeName);
-			CodeTypeReference typeReference = new CodeTypeReference(new CodeTypeReference(), arrayRank)
+			if (settings?.ArrayAsList == true || settings?.ArrayAsICollection == true)
 			{
-				ArrayElementType = elementTypeReference,
-			};
-			return typeReference;
+				var type = "System.Collections.Generic.List";
+				if (settings.ArrayAsICollection)
+					type = "System.Collections.Generic.ICollection";
+				CodeTypeReference typeReference = new CodeTypeReference(type, new[] { new CodeTypeReference(typeName) });
+				return typeReference;
+			}
+			else
+			{
+				CodeTypeReference elementTypeReference = new CodeTypeReference(typeName);
+				CodeTypeReference typeReference = new CodeTypeReference(new CodeTypeReference(), arrayRank)
+				{
+					ArrayElementType = elementTypeReference,
+				};
+				return typeReference;
+			}
+			
 		}
 
 		public static CodeTypeReference TranslateTypeNameToClientTypeReference(string typeName)

--- a/Fonlow.OpenApiClientGen.ClientTypes/ComponentsToCsTypes.cs
+++ b/Fonlow.OpenApiClientGen.ClientTypes/ComponentsToCsTypes.cs
@@ -265,7 +265,7 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 			{
 				if (enumMember is OpenApiString stringMember)
 				{
-					string memberName = NameFunc.RefineEnumMemberName(stringMember.Value);
+					string memberName = NameFunc.RefineEnumMemberName(stringMember.Value, settings);
 					bool hasFunkyMemberName = memberName != stringMember.Value;
 					int intValue = k;
 					CodeMemberField clientField = new CodeMemberField()

--- a/Fonlow.OpenApiClientGen.ClientTypes/ComponentsToCsTypes.cs
+++ b/Fonlow.OpenApiClientGen.ClientTypes/ComponentsToCsTypes.cs
@@ -136,8 +136,13 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 							if (FindTypeDeclarationInNamespaces(newTypeName, ns) == null)
 							{
 								AddTypeToCodeDom(new KeyValuePair<string, OpenApiSchema>(newTypeName, schema.Items));//so add casual type recursively
-								TypeAliasDic.Add(item.Key, $"{newTypeName}[]");
-								Trace.TraceInformation($"TypeAliasDic.Add({item.Key}, {newTypeName}[]) -- generated: {newTypeName}");
+								var typeNameX = $"{newTypeName}[]";
+								if (settings.ArrayAsICollection)
+									typeNameX = $"System.Collections.Generic.List<{newTypeName}>";
+								if (settings.ArrayAsICollection)
+									typeNameX = $"System.Collections.Generic.ICollection<{newTypeName}>";
+								TypeAliasDic.Add(item.Key, typeNameX);
+								Trace.TraceInformation($"TypeAliasDic.Add({item.Key}, {typeNameX}) -- generated: {newTypeName}");
 							}
 						}
 						else
@@ -161,13 +166,23 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 					//Array type with ref to the other type
 					if (TypeAliasDic.TryGet(itemsRef.Id, out string arrayTypeAlias))
 					{
-						TypeAliasDic.Add(item.Key, $"{arrayTypeAlias}[]");
-						Trace.TraceInformation($"TypeAliasDic.Add({item.Key}, {arrayTypeAlias}[]) with existing ({itemsRef.Id}, {arrayTypeAlias})");
+						var typeNameX = $"{arrayTypeAlias}[]";
+						if (settings.ArrayAsICollection)
+							typeNameX = $"System.Collections.Generic.List<{arrayTypeAlias}>";
+						if (settings.ArrayAsICollection)
+							typeNameX = $"System.Collections.Generic.ICollection<{arrayTypeAlias}>";
+						TypeAliasDic.Add(item.Key, typeNameX);
+						Trace.TraceInformation($"TypeAliasDic.Add({item.Key}, {typeNameX}) with existing ({itemsRef.Id}, {arrayTypeAlias})");
 					}
 					else
 					{
-						TypeAliasDic.Add(item.Key, $"{itemsRef.Id}[]");
-						Trace.TraceInformation($"TypeAliasDic.Add({item.Key}, {itemsRef.Id}[])");
+						var typeNameX = $"{itemsRef.Id}[]";
+						if (settings.ArrayAsICollection)
+							typeNameX = $"System.Collections.Generic.List<{itemsRef.Id}>";
+						if (settings.ArrayAsICollection)
+							typeNameX = $"System.Collections.Generic.ICollection<{itemsRef.Id}>";
+						TypeAliasDic.Add(item.Key, typeNameX);
+						Trace.TraceInformation($"TypeAliasDic.Add({item.Key}, {typeNameX})");
 					}
 				}
 				else if (type != "object" && !String.IsNullOrEmpty(type))
@@ -216,9 +231,19 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 				if (settings.DecorateDataModelWithDataContract)
 				{
 					typeDeclaration.CustomAttributes.Add(new CodeAttributeDeclaration("System.Runtime.Serialization.DataContract", new CodeAttributeArgument("Namespace", new CodeSnippetExpression($"\"{settings.DataContractNamespace}\""))));
+					//net 5.0 https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-customize-properties#enums-as-strings
 					if (settings.EnumToString)
 					{
-						typeDeclaration.CustomAttributes.Add(new CodeAttributeDeclaration("JsonConverter", new CodeAttributeArgument(new CodeSnippetExpression("typeof(Newtonsoft.Json.Converters.StringEnumConverter)"))));
+						if (settings.UseSystemTextJson)
+						{
+							//[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
+							typeDeclaration.CustomAttributes.Add(new CodeAttributeDeclaration("System.Text.Json.Serialization.JsonConverter", new CodeAttributeArgument(new CodeSnippetExpression("typeof(System.Text.Json.Serialization.JsonStringEnumConverter)"))));
+						}
+						else
+						{
+							//[JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+							typeDeclaration.CustomAttributes.Add(new CodeAttributeDeclaration("JsonConverter", new CodeAttributeArgument(new CodeSnippetExpression("typeof(Newtonsoft.Json.Converters.StringEnumConverter)"))));
+						}
 					}
 				}
 
@@ -386,7 +411,7 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 					{
 						Tuple<CodeTypeReference, bool> r = CreateCodeTypeReferenceSchemaOf(propertySchema, currentTypeName, p.Key);
 						bool isClass = r.Item2;
-						if (!isClass && !isRequired) //C#
+						if (!settings.DisableSystemNullableByDefault && !isClass && !isRequired || propertySchema.Nullable) //C#
 						{
 							clientProperty = CreateNullableProperty(r.Item1, propertyName);
 						}
@@ -430,7 +455,7 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 					CodeTypeReference dicValueTypeRef;
 					if (propertySchema.AdditionalProperties.Properties.Count == 0 //not casual type
 						&& propertySchema.AdditionalProperties.Reference == null // not complex type
-						&& propertySchema.AdditionalProperties.Items ==null) // not casual array type
+						&& propertySchema.AdditionalProperties.Items == null) // not casual array type
 					{
 						dicValueTypeRef = new CodeTypeReference(typeof(object));
 					}
@@ -445,9 +470,9 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 				else if (propertySchema.Enum.Count == 0) // for primitive type
 				{
 					Type simpleType = TypeRefHelper.PrimitiveSwaggerTypeToClrType(primitivePropertyType, propertySchema.Format);
-					if (!simpleType.IsClass && !isRequired) //C#
+					if (!settings.DisableSystemNullableByDefault && !simpleType.IsClass && !isRequired || propertySchema.Nullable) //C#
 					{
-						clientProperty = CreateNullableProperty(propertyName, simpleType);
+						clientProperty = CreateNullableProperty(propertyName, simpleType, settings, propertySchema.Nullable);
 					}
 					else
 					{
@@ -474,14 +499,7 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 					{
 						string existingTypeName = existingDeclaration.Name;
 						CodeTypeReference enumReference = TypeRefHelper.TranslateToClientTypeReference(existingTypeName);
-						if (isRequired)
-						{
-							clientProperty = CreateProperty(enumReference, propertyName, String.IsNullOrEmpty(defaultValue) ? null : enumReference.BaseType + "." + defaultValue);
-						}
-						else
-						{
-							clientProperty = CreateNullableProperty(enumReference, propertyName);
-						}
+						clientProperty = CreateProperty(enumReference, propertyName, String.IsNullOrEmpty(defaultValue) ? null : enumReference.BaseType + "." + defaultValue);
 					}
 					else
 					{
@@ -525,6 +543,21 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 			if (settings.DataAnnotationsEnabled) //C#
 			{
 				AddValidationAttributes(propertySchema, clientProperty);
+			}
+
+			if (settings.DecorateDataModelWithPropertyName) //C#
+			{
+				string originalPropertyName = p.Key;
+				if (settings.UseSystemTextJson)
+				{
+					//[System.Text.Json.Serialization.JsonPropertyName("name")]
+					clientProperty.CustomAttributes.Add(new CodeAttributeDeclaration("System.Text.Json.Serialization.JsonPropertyName", new CodeAttributeArgument(new CodeSnippetExpression($"\"{originalPropertyName}\""))));
+				}
+				else
+				{
+					//[Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+					clientProperty.CustomAttributes.Add(new CodeAttributeDeclaration("Newtonsoft.Json.JsonProperty", new CodeAttributeArgument("PropertyName", new CodeSnippetExpression($"\"{originalPropertyName}\""))));
+				}
 			}
 
 			CreateMemberDocComment(p, clientProperty);
@@ -645,7 +678,17 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 
 					if (settings.EnumToString)
 					{
-						r.Item2.CustomAttributes.Add(new CodeAttributeDeclaration("JsonConverter", new CodeAttributeArgument(new CodeSnippetExpression("typeof(Newtonsoft.Json.Converters.StringEnumConverter)"))));
+						if (settings.UseSystemTextJson)
+						{
+							//[System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))]
+							r.Item2.CustomAttributes.Add(new CodeAttributeDeclaration("System.Text.Json.Serialization.JsonConverter", new CodeAttributeArgument(new CodeSnippetExpression("typeof(System.Text.Json.Serialization.JsonStringEnumConverter)"))));
+
+						}
+						else
+						{
+							//[JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+							r.Item2.CustomAttributes.Add(new CodeAttributeDeclaration("JsonConverter", new CodeAttributeArgument(new CodeSnippetExpression("typeof(Newtonsoft.Json.Converters.StringEnumConverter)"))));
+						}
 					}
 				}
 
@@ -655,16 +698,7 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 				}
 			}
 
-			var isRequired = propertySchema.Required.Contains(propertyName);
-
-			if (isRequired)
-			{
-				return CreateProperty(r.Item1, propertyName, defaultValue == null ? null : (r.Item2.Name + "." + defaultValue));
-			}
-			else
-			{
-				return CreateNullableProperty(r.Item1, propertyName);
-			}
+			return CreateProperty(r.Item1, propertyName, defaultValue == null ? null : (r.Item2.Name + "." + defaultValue));
 		}
 
 		static string GetDefaultValue(OpenApiSchema s)
@@ -780,18 +814,31 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 			return result;
 		}
 
-		static CodeMemberField CreateNullableProperty(string propertyName, Type type)
+		static CodeMemberField CreateNullableProperty(string propertyName, Type type, Settings settings, bool propertyNullable = false)
 		{
-			Debug.Assert(type.IsValueType);
+			if (!propertyNullable && !settings.UseCSharpNullable)
+			{
+				Debug.Assert(type.IsValueType);
+			}
+
 			// This is a little hack. Since you cant create auto properties in CodeDOM,
 			//  we make the getter and setter part of the member name.
 			// This leaves behind a trailing semicolon that we comment out.
 			//  Later, we remove the commented out semicolons.
 			string memberName = propertyName + " { get; set; }//";
 
-			CodeMemberField result = new CodeMemberField($"System.Nullable<{type.FullName}>", memberName)
+			var typeName = settings.UseCSharpNullable ? $"{type.FullName}?" : $"System.Nullable<{type.FullName}>";
+			//c# 8.0 - compat for types that don't support nullable and openapi is set to nullable and not using UseCSharpNullable
+			//i.e: OpenapiDirectoryTests Test_randommer, Test_vimeo and Test_wheretocredit
+			if (propertyNullable)
 			{
-				Attributes = MemberAttributes.Public | MemberAttributes.Final
+				if (typeof(String) == type)
+					typeName = $"{type.FullName}?";
+			}
+
+			CodeMemberField result = new CodeMemberField(typeName, memberName)
+			{
+				Attributes = MemberAttributes.Public | MemberAttributes.Final,
 			};
 			return result;
 		}

--- a/Fonlow.OpenApiClientGen.ClientTypes/ComponentsToTypesBase.cs
+++ b/Fonlow.OpenApiClientGen.ClientTypes/ComponentsToTypesBase.cs
@@ -240,17 +240,17 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 				{
 					if (!TypeRefHelper.IsSwaggerPrimitive(arrayTypeNameAlias))
 					{
-						return Tuple.Create(ComponentsHelper.CreateArrayOfCustomTypeReference(arrayTypeNameAlias, 1), String.Empty);
+						return Tuple.Create(ComponentsHelper.CreateArrayOfCustomTypeReference(arrayTypeNameAlias, 1, settings), String.Empty);
 					}
 					else
 					{
 						var clrType = TypeRefHelper.PrimitiveSwaggerTypeToClrType(arrayTypeNameAlias, null);
-						return Tuple.Create(ComponentsHelper.CreateArrayOfCustomTypeReference(clrType.FullName, 1), String.Empty);
+						return Tuple.Create(ComponentsHelper.CreateArrayOfCustomTypeReference(clrType.FullName, 1, settings), String.Empty);
 					}
 				}
 				else
 				{
-					return Tuple.Create(ComponentsHelper.CreateArrayOfCustomTypeReference(arrayTypeWithNs, 1), String.Empty);
+					return Tuple.Create(ComponentsHelper.CreateArrayOfCustomTypeReference(arrayTypeWithNs, 1, settings), String.Empty);
 				}
 			}
 			else

--- a/Fonlow.OpenApiClientGen.ClientTypes/NameFunc.cs
+++ b/Fonlow.OpenApiClientGen.ClientTypes/NameFunc.cs
@@ -48,7 +48,7 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 			return ToTitleCase(rs).Replace('-', '_').Replace('[', '_').Replace("]", ""); // for something like PartialFindResult[ActivityEntryForApiContract]
 		}
 
-		public static string RefineEnumMemberName(string s)
+		public static string RefineEnumMemberName(string s, Settings settings = null)
 		{
 			if (String.IsNullOrEmpty(s))
 			{
@@ -65,6 +65,11 @@ namespace Fonlow.OpenApiClientGen.ClientTypes
 			if (int.TryParse(b, out _)) // some apis define negative value
 			{
 				b = "_" + b;
+			}
+
+			if (settings?.TitleCaseEnumValueNames == true && !b.StartsWith("_"))
+			{
+				b = System.Globalization.CultureInfo.InvariantCulture.TextInfo.ToTitleCase(b);
 			}
 
 			b = b.Replace('.', '_').Replace('-', '_').Replace(' ', '_').Replace('/', '_')

--- a/Fonlow.OpenApiClientGen.ClientTypes/Settings.cs
+++ b/Fonlow.OpenApiClientGen.ClientTypes/Settings.cs
@@ -93,7 +93,9 @@
 		public bool DecorateDataModelWithDataContract { get; set; }
 
 		/// <summary>
-		/// Serialize enum to strng. For C#, effective if DecorateDataModelWithDataContract is true, and the enum type is decorated by [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]. For TypeScript, the output is string enums.
+		/// Serialize enum to string. For C#, effective if DecorateDataModelWithDataContract is true, and the enum type is decorated by
+		/// [JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))] or [System.Text.Json.Serialization.JsonConverter(typeof(System.Text.Json.Serialization.JsonStringEnumConverter))].
+		/// For TypeScript, the output is string enums.
 		/// </summary>
 		public bool EnumToString { get; set; }
 
@@ -102,6 +104,9 @@
 		/// </summary>
 		public string DataContractNamespace { get; set; }
 
+		/// <summary>
+		/// Decorate the Data Model with the System.SerializableAttribute attribute
+		/// </summary>
 		public bool DecorateDataModelWithSerializable { get; set; }
 
 		/// <summary>
@@ -137,6 +142,41 @@
 		/// Function parameters contain a callback to handle HTTP request headers
 		/// </summary>
 		public bool HandleHttpRequestHeaders { get; set; }
+
+		/// <summary>
+		/// Use System.Text.Json instead of Newtonsoft.Json
+		/// </summary>
+		public bool UseSystemTextJson { get; set; }
+
+		/// <summary>
+		/// Generated data types will be decorated with JsonProperty with the PropertyName in C#.
+		/// </summary>
+		public bool DecorateDataModelWithPropertyName { get; set; }
+
+		/// <summary>
+		/// Disable property nullable by default. Set by the OpenApi v3 option nullable 
+		/// </summary>
+		public bool DisableSystemNullableByDefault { get; set; }
+
+		/// <summary>
+		/// Use T? instead of System.Nullable<T>. C# 8.0 feature
+		/// </summary>
+		public bool UseCSharpNullable { get; set; }
+
+		/// <summary>
+		/// Create the Model classes only
+		/// </summary>
+		public bool GenerateModelsOnly { get; set; }
+
+		/// <summary>
+		/// Create arrays as List<T>
+		/// </summary>
+		public bool ArrayAsList { get; set; }
+
+		/// <summary>
+		/// Create arrays as ICollection<T>
+		/// </summary>
+		public bool ArrayAsICollection { get; set; }
 
 		/// <summary>
 		/// Create destination folder if not exists. Applied to both CS and TS.

--- a/Fonlow.OpenApiClientGen.ClientTypes/Settings.cs
+++ b/Fonlow.OpenApiClientGen.ClientTypes/Settings.cs
@@ -178,6 +178,11 @@
 		/// </summary>
 		public bool ArrayAsICollection { get; set; }
 
+        /// <summary>
+        /// TitleCase Enum value names
+        /// </summary>
+        public bool TitleCaseEnumValueNames { get; set; }
+
 		/// <summary>
 		/// Create destination folder if not exists. Applied to both CS and TS.
 		/// </summary>

--- a/Tests/CSTests/OpenApiDirectoryAwsTests.cs
+++ b/Tests/CSTests/OpenApiDirectoryAwsTests.cs
@@ -14,661 +14,661 @@ namespace SwagTests
 		[Fact]
 		public void Test_accessanalyzer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\accessanalyzer\2019-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\accessanalyzer\2019-11-01");
 		}
 
 		[Fact]
 		public void Test_acm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\acm\2015-12-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\acm\2015-12-08");
 		}
 
 		[Fact]
 		public void Test_acmpca()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\acm-pca\2017-08-22");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\acm-pca\2017-08-22");
 		}
 
 		//[Fact]
 		//public void Test_alexaforbusiness() PhoneNumberType enum is password. Looking bad definition.
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\alexaforbusiness\2017-11-09");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\alexaforbusiness\2017-11-09");
 		//}
 
 		[Fact]
 		public void Test_amplify()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\amplify\2017-07-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\amplify\2017-07-25");
 		}
 
 		[Fact]
 		public void Test_apigatewayv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\apigatewayv2\2018-11-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\apigatewayv2\2018-11-29");
 		}
 
 		[Fact]
 		public void Test_apigatewaymanagementapi()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\apigatewaymanagementapi\2018-11-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\apigatewaymanagementapi\2018-11-29");
 		}
 
 		[Fact]
 		public void Test_appconfig()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\appconfig\2019-10-09");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\appconfig\2019-10-09");
 		}
 
 		[Fact]
 		public void Test_applicationautoscaling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\application-autoscaling\2016-02-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\application-autoscaling\2016-02-06");
 		}
 
 		[Fact]
 		public void Test_applicationinsights()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\application-insights\2018-11-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\application-insights\2018-11-25");
 		}
 
 		[Fact]
 		public void Test_appmesh()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\appmesh\2019-01-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\appmesh\2019-01-25");
 		}
 
 		[Fact]
 		public void Test_appstream()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\appstream\2016-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\appstream\2016-12-01");
 		}
 
 		[Fact]
 		public void Test_appsync()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\appsync\2017-07-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\appsync\2017-07-25");
 		}
 
 		[Fact]
 		public void Test_athena()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\athena\2017-05-18");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\athena\2017-05-18");
 		}
 
 		[Fact]
 		public void Test_autoscaling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\autoscaling\2011-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\autoscaling\2011-01-01");
 		}
 
 		[Fact]
 		public void Test_autoscalingplans()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\autoscaling-plans\2018-01-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\autoscaling-plans\2018-01-06");
 		}
 
 		[Fact]
 		public void Test_AWSMigrationHub()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\AWSMigrationHub\2017-05-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\AWSMigrationHub\2017-05-31");
 		}
 
 		[Fact]
 		public void Test_backup()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\backup\2018-11-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\backup\2018-11-15");
 		}
 
 		[Fact]
 		public void Test_batch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\batch\2016-08-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\batch\2016-08-10");
 		}
 
 		[Fact]
 		public void Test_budgets()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\budgets\2016-10-20");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\budgets\2016-10-20");
 		}
 
 		[Fact]
 		public void Test_ce()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ce\2017-10-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ce\2017-10-25");
 		}
 
 		[Fact]
 		public void Test_chime()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\chime\2018-05-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\chime\2018-05-01");
 		}
 
 		[Fact]
 		public void Test_cloud9()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloud9\2017-09-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloud9\2017-09-23");
 		}
 
 		[Fact]
 		public void Test_clouddirectory()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\clouddirectory\2017-01-11");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\clouddirectory\2017-01-11");
 		}
 
 		[Fact]
 		public void Test_cloudformation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudformation\2010-05-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudformation\2010-05-15");
 		}
 
 		[Fact]
 		public void Test_cloudfront()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudfront\2019-03-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudfront\2019-03-26");
 		}
 
 		[Fact]
 		public void Test_cloudhsmv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudhsmv2\2017-04-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudhsmv2\2017-04-28");
 		}
 
 		[Fact]
 		public void Test_cloudsearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudsearch\2013-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudsearch\2013-01-01");
 		}
 
 		[Fact]
 		public void Test_cloudsearchdomain()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudsearchdomain\2013-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudsearchdomain\2013-01-01");
 		}
 
 		[Fact]
 		public void Test_cloudtrail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudtrail\2013-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudtrail\2013-11-01");
 		}
 
 		[Fact]
 		public void Test_codebuild()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codebuild\2016-10-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codebuild\2016-10-06");
 		}
 
 		[Fact]
 		public void Test_codecommit()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codecommit\2015-04-13");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codecommit\2015-04-13");
 		}
 
 		[Fact]
 		public void Test_codedeploy()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codedeploy\2014-10-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codedeploy\2014-10-06");
 		}
 
 		[Fact]
 		public void Test_codegurureviewer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codeguru-reviewer\2019-09-19");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codeguru-reviewer\2019-09-19");
 		}
 
 		[Fact]
 		public void Test_codeguruprofiler()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codeguruprofiler\2019-07-18");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codeguruprofiler\2019-07-18");
 		}
 
 		[Fact]
 		public void Test_codepipeline()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codepipeline\2015-07-09");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codepipeline\2015-07-09");
 		}
 
 		[Fact]
 		public void Test_codestar()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codestar\2017-04-19");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codestar\2017-04-19");
 		}
 
 		[Fact]
 		public void Test_codestarconnections()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codestar-connections\2019-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codestar-connections\2019-12-01");
 		}
 
 		[Fact]
 		public void Test_codestarnotifications()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codestar-notifications\2019-10-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codestar-notifications\2019-10-15");
 		}
 
 		[Fact]
 		public void Test_cognitoidentity()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cognito-identity\2014-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cognito-identity\2014-06-30");
 		}
 
 		[Fact]
 		public void Test_cognitosync()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cognito-sync\2014-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cognito-sync\2014-06-30");
 		}
 
 		[Fact]
 		public void Test_cognitoidp()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cognito-idp\2016-04-18");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cognito-idp\2016-04-18");
 		}
 
 		[Fact]
 		public void Test_comprehend()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\comprehend\2017-11-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\comprehend\2017-11-27");
 		}
 
 		[Fact]
 		public void Test_comprehendmedical()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\comprehendmedical\2018-10-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\comprehendmedical\2018-10-30");
 		}
 
 		[Fact]
 		public void Test_computeoptimizer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\compute-optimizer\2019-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\compute-optimizer\2019-11-01");
 		}
 
 		[Fact]
 		public void Test_config()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\config\2014-11-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\config\2014-11-12");
 		}
 
 		[Fact]
 		public void Test_connect()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\connect\2017-08-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\connect\2017-08-08");
 		}
 
 		[Fact]
 		public void Test_connectparticipant()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\connectparticipant\2018-09-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\connectparticipant\2018-09-07");
 		}
 
 		[Fact]
 		public void Test_cur()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cur\2017-01-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cur\2017-01-06");
 		}
 
 		[Fact]
 		public void Test_dataexchange()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dataexchange\2017-07-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dataexchange\2017-07-25");
 		}
 
 		[Fact]
 		public void Test_datapipeline()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\datapipeline\2012-10-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\datapipeline\2012-10-29");
 		}
 
 		[Fact]
 		public void Test_datasync()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\datasync\2018-11-09");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\datasync\2018-11-09");
 		}
 
 		[Fact]
 		public void Test_dax()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dax\2017-04-19");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dax\2017-04-19");
 		}
 
 		[Fact]
 		public void Test_detective()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\detective\2018-10-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\detective\2018-10-26");
 		}
 
 		[Fact]
 		public void Test_devicefarm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\devicefarm\2015-06-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\devicefarm\2015-06-23");
 		}
 
 		[Fact]
 		public void Test_directconnect()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\directconnect\2012-10-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\directconnect\2012-10-25");
 		}
 
 		[Fact]
 		public void Test_discovery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\discovery\2015-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\discovery\2015-11-01");
 		}
 
 		[Fact]
 		public void Test_dlm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dlm\2018-01-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dlm\2018-01-12");
 		}
 
 		[Fact]
 		public void Test_dms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dms\2016-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dms\2016-01-01");
 		}
 
 		[Fact]
 		public void Test_docdb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\docdb\2014-10-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\docdb\2014-10-31");
 		}
 
 		[Fact]
 		public void Test_ds()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ds\2015-04-16");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ds\2015-04-16");
 		}
 
 		[Fact]
 		public void Test_dynamodb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dynamodb\2012-08-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dynamodb\2012-08-10");
 		}
 
 		[Fact]
 		public void Test_ebs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ebs\2019-11-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ebs\2019-11-02");
 		}
 
 		//[Fact]
 		//public void Test_ec2() I already have other test suites testing this, and compare source code.
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ec2\2016-11-15");
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ec2\2016-11-15");
 		//}
 
 		[Fact]
 		public void Test_ec2instanceconnect()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ec2-instance-connect\2018-04-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ec2-instance-connect\2018-04-02");
 		}
 
 		[Fact]
 		public void Test_ecr()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ecr\2015-09-21");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ecr\2015-09-21");
 		}
 
 		[Fact]
 		public void Test_ecs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ecs\2014-11-13");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ecs\2014-11-13");
 		}
 
 		[Fact]
 		public void Test_eks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\eks\2017-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\eks\2017-11-01");
 		}
 
 		[Fact]
 		public void Test_elasticinference()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elastic-inference\2017-07-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elastic-inference\2017-07-25");
 		}
 
 		[Fact]
 		public void Test_elasticache()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticache\2015-02-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticache\2015-02-02");
 		}
 
 		[Fact]
 		public void Test_elasticbeanstalk()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticbeanstalk\2010-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticbeanstalk\2010-12-01");
 		}
 
 		[Fact]
 		public void Test_elasticfilesystem()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticfilesystem\2015-02-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticfilesystem\2015-02-01");
 		}
 
 		[Fact]
 		public void Test_elasticloadbalancing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticloadbalancing\2012-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticloadbalancing\2012-06-01");
 		}
 
 		[Fact]
 		public void Test_elasticloadbalancingv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticloadbalancingv2\2015-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticloadbalancingv2\2015-12-01");
 		}
 
 		[Fact]
 		public void Test_elasticmapreduce()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticmapreduce\2009-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticmapreduce\2009-03-31");
 		}
 
 		[Fact]
 		public void Test_elastictranscoder()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elastictranscoder\2012-09-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elastictranscoder\2012-09-25");
 		}
 
 		[Fact]
 		public void Test_email()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\email\2010-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\email\2010-12-01");
 		}
 
 		[Fact]
 		public void Test_entitlementmarketplace()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\entitlement.marketplace\2017-01-11");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\entitlement.marketplace\2017-01-11");
 		}
 
 		[Fact]
 		public void Test_es()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\es\2015-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\es\2015-01-01");
 		}
 
 		[Fact]
 		public void Test_eventbridge()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\eventbridge\2015-10-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\eventbridge\2015-10-07");
 		}
 
 		[Fact]
 		public void Test_events()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\events\2015-10-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\events\2015-10-07");
 		}
 
 		[Fact]
 		public void Test_firehose()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\firehose\2015-08-04");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\firehose\2015-08-04");
 		}
 
 		[Fact]
 		public void Test_fms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\fms\2018-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\fms\2018-01-01");
 		}
 
 		[Fact]
 		public void Test_forecast()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\forecast\2018-06-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\forecast\2018-06-26");
 		}
 
 		[Fact]
 		public void Test_forecastquery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\forecastquery\2018-06-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\forecastquery\2018-06-26");
 		}
 
 		[Fact]
 		public void Test_frauddetector()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\frauddetector\2019-11-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\frauddetector\2019-11-15");
 		}
 
 		[Fact]
 		public void Test_fsx()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\fsx\2018-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\fsx\2018-03-01");
 		}
 
 		[Fact]
 		public void Test_gamelift()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\gamelift\2015-10-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\gamelift\2015-10-01");
 		}
 
 		[Fact]
 		public void Test_glacier()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\glacier\2012-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\glacier\2012-06-01");
 		}
 
 		[Fact]
 		public void Test_globalaccelerator()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\globalaccelerator\2018-08-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\globalaccelerator\2018-08-08");
 		}
 
 		[Fact]
 		public void Test_glue()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\glue\2017-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\glue\2017-03-31");
 		}
 
 		[Fact]
 		public void Test_greengrass()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\greengrass\2017-06-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\greengrass\2017-06-07");
 		}
 
 		[Fact]
 		public void Test_groundstation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\groundstation\2019-05-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\groundstation\2019-05-23");
 		}
 
 		[Fact]
 		public void Test_guardduty()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\guardduty\2017-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\guardduty\2017-11-28");
 		}
 
 		[Fact]
 		public void Test_health()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\health\2016-08-04");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\health\2016-08-04");
 		}
 
 		[Fact]
 		public void Test_iam()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iam\2010-05-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iam\2010-05-08");
 		}
 
 		[Fact]
 		public void Test_imagebuilder()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\imagebuilder\2019-12-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\imagebuilder\2019-12-02");
 		}
 
 		[Fact]
 		public void Test_importexport()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\importexport\2010-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\importexport\2010-06-01");
 		}
 
 		[Fact]
 		public void Test_inspector()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\inspector\2016-02-16");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\inspector\2016-02-16");
 		}
 
 		[Fact]
 		public void Test_iot()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot\2015-05-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot\2015-05-28");
 		}
 
 		[Fact]
 		public void Test_iotdata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot-data\2015-05-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot-data\2015-05-28");
 		}
 
 		[Fact]
 		public void Test_iotjobsdata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot-jobs-data\2017-09-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot-jobs-data\2017-09-29");
 		}
 
 		[Fact]
 		public void Test_iot1clickdevices()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot1click-devices\2018-05-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot1click-devices\2018-05-14");
 		}
 
 		[Fact]
 		public void Test_iot1clickprojects()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot1click-projects\2018-05-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot1click-projects\2018-05-14");
 		}
 
 		[Fact]
 		public void Test_iotanalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotanalytics\2017-11-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotanalytics\2017-11-27");
 		}
 
 		[Fact]
 		public void Test_iotevents()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotevents\2018-07-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotevents\2018-07-27");
 		}
 
 		[Fact]
 		public void Test_ioteventsdata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotevents-data\2018-10-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotevents-data\2018-10-23");
 		}
 
 		[Fact]
 		public void Test_iotsecuretunneling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotsecuretunneling\2018-10-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotsecuretunneling\2018-10-05");
 		}
 
 		[Fact]
 		public void Test_iotsitewise()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotsitewise\2019-12-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotsitewise\2019-12-02");
 		}
 
 		[Fact]
 		public void Test_iotthingsgraph()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotthingsgraph\2018-09-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotthingsgraph\2018-09-06");
 		}
 
 

--- a/Tests/CSTests/OpenApiDirectoryAwsTests2.cs
+++ b/Tests/CSTests/OpenApiDirectoryAwsTests2.cs
@@ -14,655 +14,655 @@ namespace SwagTests
 		[Fact]
 		public void Test_kafka()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kafka\2018-11-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kafka\2018-11-14");
 		}
 
 		[Fact]
 		public void Test_kendra()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kendra\2019-02-03");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kendra\2019-02-03");
 		}
 
 		[Fact]
 		public void Test_kinesis()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesis\2013-12-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesis\2013-12-02");
 		}
 
 		[Fact]
 		public void Test_kinesisvideoarchivedmedia()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesis-video-archived-media\2017-09-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesis-video-archived-media\2017-09-30");
 		}
 
 		[Fact]
 		public void Test_kinesisvideomedia()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesis-video-media\2017-09-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesis-video-media\2017-09-30");
 		}
 
 		[Fact]
 		public void Test_kinesisvideosignaling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesis-video-signaling\2019-12-04");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesis-video-signaling\2019-12-04");
 		}
 
 		[Fact]
 		public void Test_kinesisanalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesisanalytics\2015-08-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesisanalytics\2015-08-14");
 		}
 
 		[Fact]
 		public void Test_kinesisanalyticsv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesisanalyticsv2\2018-05-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesisanalyticsv2\2018-05-23");
 		}
 
 		[Fact]
 		public void Test_kinesisvideo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesisvideo\2017-09-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesisvideo\2017-09-30");
 		}
 
 		[Fact]
 		public void Test_kms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kms\2014-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kms\2014-11-01");
 		}
 
 		[Fact]
 		public void Test_lakeformation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\lakeformation\2017-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\lakeformation\2017-03-31");
 		}
 
 		[Fact]
 		public void Test_lambda()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\lambda\2015-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\lambda\2015-03-31");
 		}
 
 		[Fact]
 		public void Test_lexmodels()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\lex-models\2017-04-19");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\lex-models\2017-04-19");
 		}
 
 		[Fact]
 		public void Test_licensemanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\license-manager\2018-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\license-manager\2018-08-01");
 		}
 
 		[Fact]
 		public void Test_lightsail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\lightsail\2016-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\lightsail\2016-11-28");
 		}
 
 		[Fact]
 		public void Test_logs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\logs\2014-03-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\logs\2014-03-28");
 		}
 
 		[Fact]
 		public void Test_machinelearning()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\machinelearning\2014-12-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\machinelearning\2014-12-12");
 		}
 
 		[Fact]
 		public void Test_macie2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\macie2\2020-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\macie2\2020-01-01");
 		}
 
 		[Fact]
 		public void Test_managedblockchain()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\managedblockchain\2018-09-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\managedblockchain\2018-09-24");
 		}
 
 		[Fact]
 		public void Test_marketplacecatalog()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\marketplace-catalog\2018-09-17");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\marketplace-catalog\2018-09-17");
 		}
 
 		[Fact]
 		public void Test_marketplacecommerceanalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\marketplacecommerceanalytics\2015-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\marketplacecommerceanalytics\2015-07-01");
 		}
 
 		[Fact]
 		public void Test_mediaconnect()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediaconnect\2018-11-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediaconnect\2018-11-14");
 		}
 
 		[Fact]
 		public void Test_mediaconvert()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediaconvert\2017-08-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediaconvert\2017-08-29");
 		}
 
 		[Fact]
 		public void Test_medialive()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\medialive\2017-10-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\medialive\2017-10-14");
 		}
 
 		[Fact]
 		public void Test_mediapackage()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediapackage\2017-10-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediapackage\2017-10-12");
 		}
 
 		[Fact]
 		public void Test_mediapackagevod()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediapackage-vod\2018-11-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediapackage-vod\2018-11-07");
 		}
 
 		[Fact]
 		public void Test_mediastore()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediastore\2017-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediastore\2017-09-01");
 		}
 
 		[Fact]
 		public void Test_mediastoredata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediastore-data\2017-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediastore-data\2017-09-01");
 		}
 
 		[Fact]
 		public void Test_mediatailor()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediatailor\2018-04-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediatailor\2018-04-23");
 		}
 
 		[Fact]
 		public void Test_meteringmarketplace()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\meteringmarketplace\2016-01-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\meteringmarketplace\2016-01-14");
 		}
 
 		[Fact]
 		public void Test_migrationhubconfig()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\migrationhub-config\2019-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\migrationhub-config\2019-06-30");
 		}
 
 		[Fact]
 		public void Test_mobile()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mobile\2017-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mobile\2017-07-01");
 		}
 
 		[Fact]
 		public void Test_mobileanalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mobileanalytics\2014-06-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mobileanalytics\2014-06-05");
 		}
 
 		[Fact]
 		public void Test_monitoring()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\monitoring\2010-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\monitoring\2010-08-01");
 		}
 
 		[Fact]
 		public void Test_mq()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mq\2017-11-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mq\2017-11-27");
 		}
 
 		[Fact]
 		public void Test_mturkrequester()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mturk-requester\2017-01-17");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mturk-requester\2017-01-17");
 		}
 
 		[Fact]
 		public void Test_neptune()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\neptune\2014-10-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\neptune\2014-10-31");
 		}
 
 		[Fact]
 		public void Test_networkmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\networkmanager\2019-07-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\networkmanager\2019-07-05");
 		}
 
 		[Fact]
 		public void Test_opsworkscm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\opsworkscm\2016-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\opsworkscm\2016-11-01");
 		}
 
 		[Fact]
 		public void Test_organizations()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\organizations\2016-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\organizations\2016-11-28");
 		}
 
 		[Fact]
 		public void Test_outposts()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\outposts\2019-12-03");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\outposts\2019-12-03");
 		}
 
 		[Fact]
 		public void Test_personalize()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\personalize\2018-05-22");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\personalize\2018-05-22");
 		}
 
 		[Fact]
 		public void Test_personalizeevents()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\personalize-events\2018-03-22");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\personalize-events\2018-03-22");
 		}
 
 		[Fact]
 		public void Test_personalizeruntime()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\personalize-runtime\2018-05-22");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\personalize-runtime\2018-05-22");
 		}
 
 		[Fact]
 		public void Test_pi()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\pi\2018-02-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\pi\2018-02-27");
 		}
 
 		[Fact]
 		public void Test_pinpoint()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\pinpoint\2016-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\pinpoint\2016-12-01");
 		}
 
 		[Fact]
 		public void Test_pinpointemail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\pinpoint-email\2018-07-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\pinpoint-email\2018-07-26");
 		}
 
 		[Fact]
 		public void Test_polly()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\polly\2016-06-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\polly\2016-06-10");
 		}
 
 		[Fact]
 		public void Test_pricing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\pricing\2017-10-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\pricing\2017-10-15");
 		}
 
 		[Fact]
 		public void Test_qldb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\qldb\2019-01-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\qldb\2019-01-02");
 		}
 
 		[Fact]
 		public void Test_qldbsession()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\qldb-session\2019-07-11");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\qldb-session\2019-07-11");
 		}
 
 		[Fact]
 		public void Test_quicksight()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\quicksight\2018-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\quicksight\2018-04-01");
 		}
 
 		[Fact]
 		public void Test_ram()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ram\2018-01-04");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ram\2018-01-04");
 		}
 
 		[Fact]
 		public void Test_rds()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\rds\2014-10-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\rds\2014-10-31");
 		}
 
 		[Fact]
 		public void Test_rdsdata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\rds-data\2018-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\rds-data\2018-08-01");
 		}
 
 		[Fact]
 		public void Test_redshift()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\redshift\2012-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\redshift\2012-12-01");
 		}
 
 		[Fact]
 		public void Test_rekognition()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\rekognition\2016-06-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\rekognition\2016-06-27");
 		}
 
 		[Fact]
 		public void Test_resourcegroups()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\resource-groups\2017-11-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\resource-groups\2017-11-27");
 		}
 
 		[Fact]
 		public void Test_resourcegroupstaggingapi()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\resourcegroupstaggingapi\2017-01-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\resourcegroupstaggingapi\2017-01-26");
 		}
 
 		[Fact]
 		public void Test_robomaker()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\robomaker\2018-06-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\robomaker\2018-06-29");
 		}
 
 		[Fact]
 		public void Test_route53()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\route53\2013-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\route53\2013-04-01");
 		}
 
 		[Fact]
 		public void Test_route53domains()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\route53domains\2014-05-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\route53domains\2014-05-15");
 		}
 
 		[Fact]
 		public void Test_route53resolver()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\route53resolver\2018-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\route53resolver\2018-04-01");
 		}
 
 		[Fact]
 		public void Test_runtimelex()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\runtime.lex\2016-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\runtime.lex\2016-11-28");
 		}
 
 		[Fact]
 		public void Test_runtimesagemaker()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\runtime.sagemaker\2017-05-13");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\runtime.sagemaker\2017-05-13");
 		}
 
 		//[Fact]
 		//public void Test_s3() operation CreateMultipartUpload contains parameter uploads with enum/boolean. Look silly. 
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\s3\2006-03-01");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\s3\2006-03-01");
 		//}
 
 		[Fact]
 		public void Test_s3control()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\s3control\2018-08-20");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\s3control\2018-08-20");
 		}
 
 		[Fact]
 		public void Test_sagemaker()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sagemaker\2017-07-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sagemaker\2017-07-24");
 		}
 
 		[Fact]
 		public void Test_sagemakera2iruntime()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sagemaker-a2i-runtime\2019-11-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sagemaker-a2i-runtime\2019-11-07");
 		}
 
 		[Fact]
 		public void Test_savingsplans()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\savingsplans\2019-06-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\savingsplans\2019-06-28");
 		}
 
 		[Fact]
 		public void Test_schemas()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\schemas\2019-12-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\schemas\2019-12-02");
 		}
 
 		[Fact]
 		public void Test_sdb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sdb\2009-04-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sdb\2009-04-15");
 		}
 
 		[Fact]
 		public void Test_secretsmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\secretsmanager\2017-10-17");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\secretsmanager\2017-10-17");
 		}
 
 		[Fact]
 		public void Test_securityhub()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\securityhub\2018-10-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\securityhub\2018-10-26");
 		}
 
 		[Fact]
 		public void Test_serverlessrepo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\serverlessrepo\2017-09-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\serverlessrepo\2017-09-08");
 		}
 
 		[Fact]
 		public void Test_servicequotas()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\service-quotas\2019-06-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\service-quotas\2019-06-24");
 		}
 
 		[Fact]
 		public void Test_servicecatalog()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\servicecatalog\2015-12-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\servicecatalog\2015-12-10");
 		}
 
 		[Fact]
 		public void Test_servicediscovery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\servicediscovery\2017-03-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\servicediscovery\2017-03-14");
 		}
 
 		[Fact]
 		public void Test_sesv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sesv2\2019-09-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sesv2\2019-09-27");
 		}
 
 		[Fact]
 		public void Test_shield()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\shield\2016-06-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\shield\2016-06-02");
 		}
 
 		[Fact]
 		public void Test_signer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\signer\2017-08-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\signer\2017-08-25");
 		}
 
 		[Fact]
 		public void Test_sms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sms\2016-10-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sms\2016-10-24");
 		}
 
 		[Fact]
 		public void Test_smsvoice()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sms-voice\2018-09-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sms-voice\2018-09-05");
 		}
 
 		[Fact]
 		public void Test_snowball()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\snowball\2016-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\snowball\2016-06-30");
 		}
 
 		[Fact]
 		public void Test_sns()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sns\2010-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sns\2010-03-31");
 		}
 
 		[Fact]
 		public void Test_sqs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sqs\2012-11-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sqs\2012-11-05");
 		}
 
 		[Fact]
 		public void Test_ssm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ssm\2014-11-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ssm\2014-11-06");
 		}
 
 		[Fact]
 		public void Test_sso()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sso\2019-06-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sso\2019-06-10");
 		}
 
 		[Fact]
 		public void Test_ssooidc()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sso-oidc\2019-06-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sso-oidc\2019-06-10");
 		}
 
 		[Fact]
 		public void Test_states()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\states\2016-11-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\states\2016-11-23");
 		}
 
 		[Fact]
 		public void Test_storagegateway()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\storagegateway\2013-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\storagegateway\2013-06-30");
 		}
 
 		[Fact]
 		public void Test_streamsdynamodb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\streams.dynamodb\2012-08-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\streams.dynamodb\2012-08-10");
 		}
 
 		[Fact]
 		public void Test_sts()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sts\2011-06-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sts\2011-06-15");
 		}
 
 		[Fact]
 		public void Test_support()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\support\2013-04-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\support\2013-04-15");
 		}
 
 		[Fact]
 		public void Test_swf()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\swf\2012-01-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\swf\2012-01-25");
 		}
 
 		[Fact]
 		public void Test_synthetics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\synthetics\2017-10-11");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\synthetics\2017-10-11");
 		}
 
 		[Fact]
 		public void Test_textract()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\textract\2018-06-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\textract\2018-06-27");
 		}
 
 		[Fact]
 		public void Test_transcribe()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\transcribe\2017-10-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\transcribe\2017-10-26");
 		}
 
 		[Fact]
 		public void Test_transfer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\transfer\2018-11-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\transfer\2018-11-05");
 		}
 
 		[Fact]
 		public void Test_translate()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\translate\2017-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\translate\2017-07-01");
 		}
 
 		[Fact]
 		public void Test_waf()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\waf\2015-08-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\waf\2015-08-24");
 		}
 
 		[Fact]
 		public void Test_wafregional()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\waf-regional\2016-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\waf-regional\2016-11-28");
 		}
 
 		[Fact]
 		public void Test_wafv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\wafv2\2019-07-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\wafv2\2019-07-29");
 		}
 
 		[Fact]
 		public void Test_workdocs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\workdocs\2016-05-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\workdocs\2016-05-01");
 		}
 
 		[Fact]
 		public void Test_worklink()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\worklink\2018-09-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\worklink\2018-09-25");
 		}
 
 		[Fact]
 		public void Test_workmail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\workmail\2017-10-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\workmail\2017-10-01");
 		}
 
 		[Fact]
 		public void Test_workmailmessageflow()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\workmailmessageflow\2019-05-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\workmailmessageflow\2019-05-01");
 		}
 
 		[Fact]
 		public void Test_workspaces()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\workspaces\2015-04-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\workspaces\2015-04-08");
 		}
 
 		[Fact]
 		public void Test_xray()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\xray\2016-04-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\xray\2016-04-12");
 		}
 
 	}

--- a/Tests/CSTests/OpenApiDirectoryGoogleTests.cs
+++ b/Tests/CSTests/OpenApiDirectoryGoogleTests.cs
@@ -14,439 +14,439 @@ namespace SwagTests
 		[Fact]
 		public void Test_driveactivity()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\driveactivity\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\driveactivity\v2");
 		}
 
 		[Fact]
 		public void Test_drive()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\drive\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\drive\v3");
 		}
 
 		[Fact]
 		public void Test_doubleclicksearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\doubleclicksearch\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\doubleclicksearch\v2");
 		}
 
 		[Fact]
 		public void Test_doubleclickbidmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\doubleclickbidmanager\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\doubleclickbidmanager\v1");
 		}
 
 		[Fact]
 		public void Test_domainsrdap()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\domainsrdap\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\domainsrdap\v1");
 		}
 
 		[Fact]
 		public void Test_docs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\docs\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\docs\v1");
 		}
 
 		[Fact]
 		public void Test_dns()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dns\v2beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dns\v2beta1");
 		}
 
 		[Fact]
 		public void Test_dlp()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dlp\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dlp\v2");
 		}
 
 		[Fact]
 		public void Test_discovery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\discovery\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\discovery\v1");
 		}
 
 		[Fact]
 		public void Test_digitalassetlinks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\digitalassetlinks\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\digitalassetlinks\v1");
 		}
 
 		[Fact]
 		public void Test_dfareporting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dfareporting\v3.3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dfareporting\v3.3");
 		}
 
 		[Fact]
 		public void Test_deploymentmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\deploymentmanager\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\deploymentmanager\v2");
 		}
 
 		[Fact]
 		public void Test_datastore()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\datastore\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\datastore\v1");
 		}
 
 		[Fact]
 		public void Test_dataproc()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dataproc\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dataproc\v1");
 		}
 
 		[Fact]
 		public void Test_datafusion()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\datafusion\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\datafusion\v1beta1");
 		}
 
 		[Fact]
 		public void Test_dataflow()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dataflow\v1b3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dataflow\v1b3");
 		}
 
 		[Fact]
 		public void Test_customsearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\customsearch\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\customsearch\v1");
 		}
 
 		[Fact]
 		public void Test_content()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\content\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\content\v2");
 		}
 
 		[Fact]
 		public void Test_containeranalysis()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\containeranalysis\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\containeranalysis\v1beta1");
 		}
 
 		[Fact]
 		public void Test_container()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\container\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\container\v1");
 		}
 
 		[Fact]
 		public void Test_compute()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\compute\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\compute\v1");
 		}
 
 		[Fact]
 		public void Test_composer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\composer\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\composer\v1");
 		}
 
 		[Fact]
 		public void Test_commentanalyzer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\commentanalyzer\v1alpha1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\commentanalyzer\v1alpha1");
 		}
 
 		[Fact]
 		public void Test_cloudtrace()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudtrace\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudtrace\v2");
 		}
 
 		[Fact]
 		public void Test_cloudtasks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudtasks\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudtasks\v2");
 		}
 
 		[Fact]
 		public void Test_cloudshell()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudshell\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudshell\v1");
 		}
 
 		[Fact]
 		public void Test_cloudsearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudsearch\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudsearch\v1");
 		}
 
 		[Fact]
 		public void Test_cloudscheduler()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudscheduler\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudscheduler\v1");
 		}
 
 		[Fact]
 		public void Test_cloudresourcemanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudresourcemanager\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudresourcemanager\v2");
 		}
 
 		[Fact]
 		public void Test_cloudprofiler()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudprofiler\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudprofiler\v2");
 		}
 
 		[Fact]
 		public void Test_cloudprivatecatalogproducer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudprivatecatalogproducer\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudprivatecatalogproducer\v1beta1");
 		}
 
 		[Fact]
 		public void Test_cloudprivatecatalog()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudprivatecatalog\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudprivatecatalog\v1beta1");
 		}
 
 		[Fact]
 		public void Test_cloudkms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudkms\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudkms\v1");
 		}
 
 		[Fact]
 		public void Test_cloudiot()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudiot\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudiot\v1");
 		}
 
 		[Fact]
 		public void Test_cloudidentity()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudidentity\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudidentity\v1");
 		}
 
 		[Fact]
 		public void Test_cloudfunctions()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudfunctions\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudfunctions\v1");
 		}
 
 		[Fact]
 		public void Test_clouderrorreporting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\clouderrorreporting\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\clouderrorreporting\v1beta1");
 		}
 
 		[Fact]
 		public void Test_clouddebugger()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\clouddebugger\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\clouddebugger\v2");
 		}
 
 		[Fact]
 		public void Test_cloudbuild()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudbuild\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudbuild\v1");
 		}
 
 		[Fact]
 		public void Test_cloudbilling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudbilling\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudbilling\v1");
 		}
 
 		[Fact]
 		public void Test_cloudasset()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudasset\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudasset\v1");
 		}
 
 		[Fact]
 		public void Test_classroom()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\classroom\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\classroom\v1");
 		}
 
 		[Fact]
 		public void Test_civicinfo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\civicinfo\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\civicinfo\v2");
 		}
 
 		[Fact]
 		public void Test_chat()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\chat\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\chat\v1");
 		}
 
 		[Fact]
 		public void Test_calendar()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\calendar\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\calendar\v3");
 		}
 
 		[Fact]
 		public void Test_books()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\books\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\books\v1");
 		}
 
 		[Fact]
 		public void Test_blogger()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\blogger\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\blogger\v3");
 		}
 
 		[Fact]
 		public void Test_binaryauthorization()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\binaryauthorization\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\binaryauthorization\v1");
 		}
 
 		[Fact]
 		public void Test_bigtableadmin()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigtableadmin\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigtableadmin\v2");
 		}
 
 		[Fact]
 		public void Test_bigqueryreservation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigqueryreservation\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigqueryreservation\v1");
 		}
 
 		[Fact]
 		public void Test_bigquerydatatransfer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigquerydatatransfer\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigquerydatatransfer\v1");
 		}
 
 		[Fact]
 		public void Test_bigqueryconnection()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigqueryconnection\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigqueryconnection\v1beta1");
 		}
 
 		[Fact]
 		public void Test_bigquery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigquery\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigquery\v2");
 		}
 
 		[Fact]
 		public void Test_automl()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\automl\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\automl\v1beta1");
 		}
 
 		[Fact]
 		public void Test_appsactivity()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\appsactivity\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\appsactivity\v1");
 		}
 
 		[Fact]
 		public void Test_appengine()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\appengine\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\appengine\v1");
 		}
 
 		[Fact]
 		public void Test_androidpublisher()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\androidpublisher\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\androidpublisher\v3");
 		}
 
 		[Fact]
 		public void Test_androidmanagement()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\androidmanagement\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\androidmanagement\v1");
 		}
 
 		[Fact]
 		public void Test_androidenterprise()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\androidenterprise\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\androidenterprise\v1");
 		}
 
 		[Fact]
 		public void Test_androiddeviceprovisioning()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\androiddeviceprovisioning\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\androiddeviceprovisioning\v1");
 		}
 
 		[Fact]
 		public void Test_analyticsreporting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\analyticsreporting\v4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\analyticsreporting\v4");
 		}
 
 		[Fact]
 		public void Test_analytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\analytics\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\analytics\v3");
 		}
 
 		[Fact]
 		public void Test_alertcenter()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\alertcenter\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\alertcenter\v1beta1");
 		}
 
 		[Fact]
 		public void Test_adsensehost()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\adsensehost\v4.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\adsensehost\v4.1");
 		}
 
 		[Fact]
 		public void Test_adsense()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\adsense\v1.4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\adsense\v1.4");
 		}
 
 		[Fact]
 		public void Test_adminreports_v1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\admin\reports_v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\admin\reports_v1");
 		}
 
 		[Fact]
 		public void Test_admindatatransfer_v1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\admin\datatransfer_v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\admin\datatransfer_v1");
 		}
 
 		[Fact]
 		public void Test_adexperiencereport()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\adexperiencereport\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\adexperiencereport\v1");
 		}
 
 		[Fact]
 		public void Test_adexchangebuyer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\adexchangebuyer\v1.4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\adexchangebuyer\v1.4");
 		}
 
 		[Fact]
 		public void Test_accesscontextmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\accesscontextmanager\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\accesscontextmanager\v1");
 		}
 
 		[Fact]
 		public void Test_accessapproval()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\accessapproval\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\accessapproval\v1beta1");
 		}
 
 		[Fact]
 		public void Test_acceleratedmobilepageurl()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\acceleratedmobilepageurl\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\acceleratedmobilepageurl\v1");
 		}
 
 		[Fact]
 		public void Test_abusiveexperiencereport()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\abusiveexperiencereport\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\abusiveexperiencereport\v1");
 		}
 
 	}

--- a/Tests/CSTests/OpenApiDirectoryGoogleTests2.cs
+++ b/Tests/CSTests/OpenApiDirectoryGoogleTests2.cs
@@ -14,499 +14,499 @@ namespace SwagTests
 		[Fact]
 		public void Test_youtubeAnalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\youtubeAnalytics\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\youtubeAnalytics\v2");
 		}
 
 		[Fact]
 		public void Test_youtubereporting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\youtubereporting\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\youtubereporting\v1");
 		}
 
 		[Fact]
 		public void Test_youtube()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\youtube\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\youtube\v3");
 		}
 
 		[Fact]
 		public void Test_websecurityscanner()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\websecurityscanner\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\websecurityscanner\v1");
 		}
 
 		[Fact]
 		public void Test_webmasters()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\webmasters\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\webmasters\v3");
 		}
 
 		[Fact]
 		public void Test_webfonts()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\webfonts\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\webfonts\v1");
 		}
 
 		[Fact]
 		public void Test_vision()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\vision\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\vision\v1");
 		}
 
 		[Fact]
 		public void Test_videointelligence()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\videointelligence\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\videointelligence\v1");
 		}
 
 		[Fact]
 		public void Test_verifiedaccess()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\verifiedaccess\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\verifiedaccess\v1");
 		}
 
 		[Fact]
 		public void Test_vault()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\vault\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\vault\v1");
 		}
 
 		[Fact]
 		public void Test_translate()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\translate\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\translate\v2");
 		}
 
 		[Fact]
 		public void Test_tpu()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\tpu\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\tpu\v1");
 		}
 
 		[Fact]
 		public void Test_texttospeech()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\texttospeech\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\texttospeech\v1");
 		}
 
 		[Fact]
 		public void Test_testing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\testing\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\testing\v1");
 		}
 
 		[Fact]
 		public void Test_tasks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\tasks\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\tasks\v1");
 		}
 
 		[Fact]
 		public void Test_tagmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\tagmanager\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\tagmanager\v1");
 		}
 
 		[Fact]
 		public void Test_streetviewpublish()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\streetviewpublish\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\streetviewpublish\v1");
 		}
 
 		[Fact]
 		public void Test_storagetransfer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\storagetransfer\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\storagetransfer\v1");
 		}
 
 		[Fact]
 		public void Test_storage()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\storage\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\storage\v1");
 		}
 
 		[Fact]
 		public void Test_sqladmin()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\sqladmin\v1beta4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\sqladmin\v1beta4");
 		}
 
 		[Fact]
 		public void Test_speech()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\speech\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\speech\v1");
 		}
 
 		[Fact]
 		public void Test_spanner()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\spanner\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\spanner\v1");
 		}
 
 		[Fact]
 		public void Test_sourcerepo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\sourcerepo\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\sourcerepo\v1");
 		}
 
 		[Fact]
 		public void Test_slides()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\slides\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\slides\v1");
 		}
 
 		[Fact]
 		public void Test_siteVerification()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\siteVerification\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\siteVerification\v1");
 		}
 
 		[Fact]
 		public void Test_sheets()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\sheets\v4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\sheets\v4");
 		}
 
 		[Fact]
 		public void Test_serviceusage()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\serviceusage\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\serviceusage\v1");
 		}
 
 		[Fact]
 		public void Test_servicenetworking()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\servicenetworking\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\servicenetworking\v1");
 		}
 
 		[Fact]
 		public void Test_servicemanagement()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\servicemanagement\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\servicemanagement\v1");
 		}
 
 		[Fact]
 		public void Test_servicecontrol()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\servicecontrol\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\servicecontrol\v1");
 		}
 
 		[Fact]
 		public void Test_serviceconsumermanagement()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\serviceconsumermanagement\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\serviceconsumermanagement\v1");
 		}
 
 		[Fact]
 		public void Test_servicebroker()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\servicebroker\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\servicebroker\v1");
 		}
 
 		[Fact]
 		public void Test_securitycenter()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\securitycenter\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\securitycenter\v1");
 		}
 
 		[Fact]
 		public void Test_searchconsole()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\searchconsole\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\searchconsole\v1");
 		}
 
 		[Fact]
 		public void Test_script()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\script\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\script\v1");
 		}
 
 		[Fact]
 		public void Test_safebrowsing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\safebrowsing\v4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\safebrowsing\v4");
 		}
 
 		[Fact]
 		public void Test_runtimeconfig()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\runtimeconfig\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\runtimeconfig\v1");
 		}
 
 		[Fact]
 		public void Test_run()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\run\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\run\v1");
 		}
 
 		[Fact]
 		public void Test_reseller()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\reseller\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\reseller\v1");
 		}
 
 		[Fact]
 		public void Test_replicapool()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\replicapool\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\replicapool\v1beta1");
 		}
 
 		[Fact]
 		public void Test_remotebuildexecution()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\remotebuildexecution\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\remotebuildexecution\v1");
 		}
 
 		[Fact]
 		public void Test_redis()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\redis\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\redis\v1");
 		}
 
 		[Fact]
 		public void Test_recommender()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\recommender\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\recommender\v1beta1");
 		}
 
 		[Fact]
 		public void Test_pubsub()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\pubsub\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\pubsub\v1");
 		}
 
 		[Fact]
 		public void Test_proximitybeacon()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\proximitybeacon\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\proximitybeacon\v1beta1");
 		}
 
 		[Fact]
 		public void Test_poly()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\poly\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\poly\v1");
 		}
 
 		[Fact]
 		public void Test_policytroubleshooter()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\policytroubleshooter\v1beta");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\policytroubleshooter\v1beta");
 		}
 
 		[Fact]
 		public void Test_playcustomapp()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\playcustomapp\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\playcustomapp\v1");
 		}
 
 		[Fact]
 		public void Test_people()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\people\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\people\v1");
 		}
 
 		[Fact]
 		public void Test_pagespeedonline()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\pagespeedonline\v5");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\pagespeedonline\v5");
 		}
 
 		[Fact]
 		public void Test_oslogin()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\oslogin\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\oslogin\v1");
 		}
 
 		[Fact]
 		public void Test_oauth2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\oauth2\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\oauth2\v2");
 		}
 
 		[Fact]
 		public void Test_monitoring()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\monitoring\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\monitoring\v3");
 		}
 
 		[Fact]
 		public void Test_mirror()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\mirror\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\mirror\v1");
 		}
 
 		[Fact]
 		public void Test_manufacturers()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\manufacturers\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\manufacturers\v1");
 		}
 
 		[Fact]
 		public void Test_logging()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\logging\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\logging\v2");
 		}
 
 		[Fact]
 		public void Test_licensing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\licensing\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\licensing\v1");
 		}
 
 		[Fact]
 		public void Test_libraryagent()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\libraryagent\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\libraryagent\v1");
 		}
 
 		[Fact]
 		public void Test_language()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\language\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\language\v1");
 		}
 
 		//[Fact]
 		//public void Test_kgsearch() very short. And SearchResponse is having @context
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\kgsearch\v1");
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\googleapis.com\kgsearch\v1");
 		//}
 
 		[Fact]
 		public void Test_jobs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\jobs\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\jobs\v3");
 		}
 
 		[Fact]
 		public void Test_indexing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\indexing\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\indexing\v3");
 		}
 
 		[Fact]
 		public void Test_identitytoolkit()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\identitytoolkit\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\identitytoolkit\v3");
 		}
 
 		[Fact]
 		public void Test_iap()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\iap\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\iap\v1");
 		}
 
 		[Fact]
 		public void Test_iamcredentials()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\iamcredentials\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\iamcredentials\v1");
 		}
 
 		[Fact]
 		public void Test_iam()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\iam\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\iam\v1");
 		}
 
 		[Fact]
 		public void Test_homegraph()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\homegraph\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\homegraph\v1");
 		}
 
 		[Fact]
 		public void Test_healthcare()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\healthcare\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\healthcare\v1beta1");
 		}
 
 		[Fact]
 		public void Test_groupssettings()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\groupssettings\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\groupssettings\v1");
 		}
 
 		[Fact]
 		public void Test_groupsmigration()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\groupsmigration\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\groupsmigration\v1");
 		}
 
 		[Fact]
 		public void Test_gmail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\gmail\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\gmail\v1");
 		}
 
 		[Fact]
 		public void Test_genomics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\genomics\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\genomics\v1");
 		}
 
 		[Fact]
 		public void Test_gamesManagement()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\gamesManagement\v1management");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\gamesManagement\v1management");
 		}
 
 		[Fact]
 		public void Test_gamesConfiguration()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\gamesConfiguration\v1configuration");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\gamesConfiguration\v1configuration");
 		}
 
 		[Fact]
 		public void Test_games()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\games\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\games\v1");
 		}
 
 		[Fact]
 		public void Test_fitness()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\fitness\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\fitness\v1");
 		}
 
 		[Fact]
 		public void Test_firestore()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\firestore\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\firestore\v1");
 		}
 
 		[Fact]
 		public void Test_firebaserules()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\firebaserules\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\firebaserules\v1");
 		}
 
 		[Fact]
 		public void Test_firebasehosting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\firebasehosting\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\firebasehosting\v1beta1");
 		}
 
 		[Fact]
 		public void Test_firebasedynamiclinks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\firebasedynamiclinks\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\firebasedynamiclinks\v1");
 		}
 
 		[Fact]
 		public void Test_file()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\file\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\file\v1");
 		}
 
 		[Fact]
 		public void Test_fcm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\fcm\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\fcm\v1");
 		}
 
 		[Fact]
 		public void Test_factchecktools()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\factchecktools\v1alpha1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\factchecktools\v1alpha1");
 		}
 
 

--- a/Tests/CSTests/OpenApiDirectoryTests.cs
+++ b/Tests/CSTests/OpenApiDirectoryTests.cs
@@ -15,202 +15,202 @@ namespace SwagTests
 		[Fact]
 		public void Test_wheretocredit()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wheretocredit.com\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wheretocredit.com\1.0");
 		}
 
 		[Fact]
 		public void Test_vonagevgis()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vonage.com\vgis\1.0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vonage.com\vgis\1.0.1");
 		}
 
 		[Fact]
 		public void Test_vonageuser()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vonage.com\user\1.11.8");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vonage.com\user\1.11.8");
 		}
 
 		[Fact]
 		public void Test_vonageaccount()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vonage.com\account\1.11.8");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vonage.com\account\1.11.8");
 		}
 
 
 		[Fact]
 		public void Test_vimeo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vimeo.com\3.4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vimeo.com\3.4");
 		}
 
 		//[Fact]System.ArgumentException : Not yet supported enumMember of Microsoft.OpenApi.Any.OpenApiBoolean with HideReplyByIdBodyHidden
 		//Enum with boolean in operation HideReplyById. Nswag could not either.
 		//public void Test_twitter()
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\twitter.com\labs\2.7");
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\twitter.com\labs\2.7");
 		//}
 
 		[Fact]
 		public void Test_tomtomsearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tomtom.com\search\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tomtom.com\search\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_tomtomrouting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tomtom.com\routing\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tomtom.com\routing\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_tomtommaps()//empty property 
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tomtom.com\maps\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tomtom.com\maps\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_tisane()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tisane.ai\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tisane.ai\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_stackexchange() has a array type member property: 'the id of the object (answer, comment, question, or user) the event describes'
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\stackexchange.com\2.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\stackexchange.com\2.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		//[Fact]
 		//public void Test_shutterstock()//has duplicate definitions of api calls.
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\shutterstock.com\1.0.16", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\shutterstock.com\1.0.16", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_ritekit()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ritekit.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ritekit.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_football()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\rapidapi.com\football-prediction\2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\rapidapi.com\football-prediction\2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_rebilly()
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\rebilly.com\2.1");wrong definitions with duplicated enum member voided in billingStatus.
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\rebilly.com\2.1");wrong definitions with duplicated enum member voided in billingStatus.
 		//}
 
 		[Fact]
 		public void Test_randommer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\randommer.io\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\randommer.io\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_patientview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\patientview.org\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\patientview.org\1.0");
 		}
 
 		[Fact]
 		public void Test_parliament()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\parliament.uk\search\Live");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\parliament.uk\search\Live");
 		}
 
 		[Fact]
 		public void Test_openlinksw()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\openlinksw.com\osdb\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\openlinksw.com\osdb\1.0.0");
 		}
 
 		[Fact]
 		public void Test_opendatanetwork()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\opendatanetwork.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\opendatanetwork.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_oceandrivers()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\oceandrivers.com\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\oceandrivers.com\1.0");
 		}
 
 		[Fact]
 		public void Test_nsidc()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\nsidc.org\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\nsidc.org\1.0.0");
 		}
 
 		//[Fact]
 		//public void Test_domainfinder() //empty property?
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\nic.at\domainfinder\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\nic.at\domainfinder\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_neowsapp()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\neowsapp.com\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\neowsapp.com\1.0");
 		}
 
 		[Fact]
 		public void Test_namsor()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\namsor.com\2.0.5");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\namsor.com\2.0.5");
 		}
 
 		[Fact]
 		public void Test_math()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\math.tools\1.5", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\math.tools\1.5", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_listennotes() //it has funky casual enum in operation, with type double and default value. Code generated won't pass compilation. Better not to tolerate such definitiohn.
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\listennotes.com\2.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\listennotes.com\2.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		//[Fact]
 		//public void Test_linode()// The Grant type has a casual enum definition with member null. OpenApi lib could not intepret it well
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\linode.com\4.5.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\linode.com\4.5.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_iptwist()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\iptwist.com\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\iptwist.com\1.0.0");
 		}
 
 		[Fact]
 		public void Test_ipinfodb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ipinfodb.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ipinfodb.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_mycru()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\mycru.io\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\mycru.io\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_mercure()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\mercure.local\0.3.2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\mercure.local\0.3.2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_microsoftgraph()
 		//{
 		//	//ms graph yaml has some funky paths like /groups/{group-id}/calendar/calendarView/{event-id}/instances/{event-id}, duplicate parameters.
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\graph\1.0.1", new Settings()
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\microsoft.com\graph\1.0.1", new Settings()
 		//	{
 		//		ClientNamespace = "MyNS",
 		//		//NamespaceInClassName = "microsoft.graph.",
@@ -230,67 +230,67 @@ namespace SwagTests
 		[Fact]
 		public void Test_ip2whois()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ip2whois.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ip2whois.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_ip2proxy()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ip2proxy.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ip2proxy.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_geolocation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ip2location.com\geolocation\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ip2location.com\geolocation\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_convertcurrency()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\interzoid.com\convertcurrency\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\interzoid.com\convertcurrency\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_getaddressmatch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\interzoid.com\getaddressmatch\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\interzoid.com\getaddressmatch\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_getareacodefromnumber()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\interzoid.com\getareacodefromnumber\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\interzoid.com\getareacodefromnumber\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_getcitymatch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\interzoid.com\getcitymatch\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\interzoid.com\getcitymatch\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_hackathonwatch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\hackathonwatch.com\0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\hackathonwatch.com\0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_bcdc()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\gov.bc.ca\bcdc\3.0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\gov.bc.ca\bcdc\3.0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_bcgnws()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\gov.bc.ca\bcgnws\3.x.x", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\gov.bc.ca\bcgnws\3.x.x", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_geocoder()has invalid url sites/{siteID}/subsites.{outputFormat} and sites/{siteID}.{outputFormat},  https://stackoverflow.com/questions/3856693/a-url-resource-that-is-a-dot-2e
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\gov.bc.ca\geocoder\2.0.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\gov.bc.ca\geocoder\2.0.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 

--- a/Tests/CsSwagger2Tests/ODAzureTests.cs
+++ b/Tests/CsSwagger2Tests/ODAzureTests.cs
@@ -1,1512 +1,1513 @@
 using Fonlow.OpenApiClientGen.ClientTypes;
+
 using Xunit;
 using Xunit.Abstractions;
 
 namespace SwagTests
 {
-	public class ODAzureTests
-	{
-		readonly CSharpTestHelper helper;
-		public ODAzureTests(ITestOutputHelper output)
-		{
-			helper = new CSharpTestHelper(output);
-		}
-
-		[Fact]
-		public void Test_Addons()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\addons-Addons\2017-05-15");
-		}
-
-		[Fact]
-		public void Test_advisor()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\advisor\2020-01-01");
-		}
-
-		[Fact]
-		public void Test_alertsmanagementAlertsManagement()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\alertsmanagement-AlertsManagement\2019-03-01");
-		}
-
-		[Fact]
-		public void Test_alertsmanagementSmartDetectorAlertRulesApi()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\alertsmanagement-SmartDetectorAlertRulesApi\2019-06-01");
-		}
-
-		[Fact]
-		public void Test_analysisservices()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\analysisservices\2017-08-01");
-		}
-
-		[Fact]
-		public void Test_apimanagement()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\apimanagement\2019-01-01");
-		}
-
-		[Fact]
-		public void Test_appconfiguration()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\appconfiguration\2019-10-01");
-		}
-
-		[Fact]
-		public void Test_applicationinsightscomponentAnnotations_API()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\applicationinsights-componentAnnotations_API\2015-05-01");
-		}
-
-		[Fact]
-		public void Test_applicationinsightscomponentFeaturesAndPricing_API()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\applicationinsights-componentFeaturesAndPricing_API\2017-10-01");
-		}
-
-		[Fact]
-		public void Test_applicationinsightscomponentProactiveDetection_API()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\applicationinsights-componentProactiveDetection_API\2015-05-01");
-		}
-
-		//[Fact]
-		//public void Test_applicationinsightscomponents_API() it seems invalid. Nswag throws exceptions.
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\applicationinsights-components_API\2015-05-01");
-		//}
-
-		[Fact]
-		public void Test_appplatform()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\appplatform\2019-05-01-preview");
-		}
-
-		[Fact]
-		public void Test_attestation()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\attestation\2018-09-01-preview");
-		}
-
-		[Fact]
-		public void Test_authorization()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\authorization\2015-07-01");
-		}
-
-		[Fact]
-		public void Test_authorizationauthorizationProviderOperationsCalls()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\authorization-authorization-ProviderOperationsCalls\2018-01-01-preview");
-		}
-
-		[Fact]
-		public void Test_authorizationauthorizationRoleAssignmentsCalls()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\authorization-authorization-RoleAssignmentsCalls\2018-09-01-preview");
-		}
-
-		[Fact]
-		public void Test_authorizationauthorizationRoleDefinitionsCalls()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\authorization-authorization-RoleDefinitionsCalls\2018-01-01-preview");
-		}
-
-		[Fact]
-		public void Test_automationaccount()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-account\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_automationcertificate()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-certificate\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_automationconnection()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-connection\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_automationconnectionType()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-connectionType\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_automationdefinitions()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-definitions\2018-06-10");
-		}
-
-		[Fact]
-		public void Test_automationdscCompilationJob()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-dscCompilationJob\2018-01-15");
-		}
-
-		[Fact]
-		public void Test_automationdscNodeCounts()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-dscNodeCounts\2018-01-15");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_hybridRunbookWorkerGroup_2015_10_31()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-hybridRunbookWorkerGroup\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_job_2017_05_15_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-job\2017-05-15-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_jobSchedule_2015_10_31()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-jobSchedule\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_linkedWorkspace_2015_10_31()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-linkedWorkspace\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_module_2015_10_31()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-module\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_python2package_2018_06_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-python2package\2018-06-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_runbook_2018_06_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-runbook\2018-06-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_schedule_2015_10_31()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-schedule\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_softwareUpdateConfiguration_2017_05_15_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-softwareUpdateConfiguration\2017-05-15-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_softwareUpdateConfigurationMachineRun_2017_05_15_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-softwareUpdateConfigurationMachineRun\2017-05-15-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_softwareUpdateConfigurationRun_2017_05_15_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-softwareUpdateConfigurationRun\2017-05-15-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_sourceControl_2017_05_15_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-sourceControl\2017-05-15-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_sourceControlSyncJob_2017_05_15_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-sourceControlSyncJob\2017-05-15-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_sourceControlSyncJobStreams_2017_05_15_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-sourceControlSyncJobStreams\2017-05-15-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_variable_2015_10_31()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-variable\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_watcher_2015_10_31()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-watcher\2015-10-31");
-		}
-
-		[Fact]
-		public void Test_azure_com_automation_webhook_2015_10_31()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\automation-webhook\2015-10-31");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_azsadmin_AcquiredPlan_2015_11_01() invalid using parameters rather than definitions for components.
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-AcquiredPlan\2015-11-01");
-		//}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_acquisitions_2019_08_08_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-acquisitions\2019-08-08-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_ActionPlan_2019_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-ActionPlan\2019-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_ActionPlanOperation_2019_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-ActionPlanOperation\2019-01-01");
-		}
-
-
-		[Fact]
-		public void Test_azure_com_azsadmin_ApplicationOperationResults_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-ApplicationOperationResults\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Backup_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Backup\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Backup_2018_09_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Backup\2018-09-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_blobServices_2015_12_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-blobServices\2015-12-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Commerce_2015_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Commerce\2015-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_CommerceAdmin_2015_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-CommerceAdmin\2015-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Compute_2015_12_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Compute\2015-12-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_ComputeOperationResults_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-ComputeOperationResults\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_DelegatedProvider_2015_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-DelegatedProvider\2015-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_DelegatedProviderOffer_2015_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-DelegatedProviderOffer\2015-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Deployment_2019_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Deployment\2019-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_DiskMigrationJobs_2018_07_30_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-DiskMigrationJobs\2018-07-30-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Disks_2018_07_30_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Disks\2018-07-30-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Drive_2019_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Drive\2019-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_EdgeGateway_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-EdgeGateway\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_EdgeGatewayPool_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-EdgeGatewayPool\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Fabric_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Fabric\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_FabricLocation_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-FabricLocation\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_farms_2015_12_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-farms\2015-12-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_FileContainer_2019_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-FileContainer\2019-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_FileShare_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-FileShare\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Gallery_2015_04_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Gallery\2015-04-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_InfraRole_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-InfraRole\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_InfraRoleInstance_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-InfraRoleInstance\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_InfrastructureInsights_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-InfrastructureInsights\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_KeyVault_2017_02_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-KeyVault\2017-02-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_LoadBalancers_2015_06_15()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-LoadBalancers\2015-06-15");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_LogicalNetwork_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-LogicalNetwork\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_LogicalSubnet_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-LogicalSubnet\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_MacAddressPool_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-MacAddressPool\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Manifest_2015_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Manifest\2015-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Network_2015_06_15()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Network\2015-06-15");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_NetworkOperationResults_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-NetworkOperationResults\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Offer_2015_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Offer\2015-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Operations_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Operations\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Product_2016_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Product\2016-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_ProductDeployment_2019_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-ProductDeployment\2019-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_ProductPackage_2019_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-ProductPackage\2019-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_ProductSecret_2019_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-ProductSecret\2019-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_PublicIpAddresses_2015_06_15()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-PublicIpAddresses\2015-06-15");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_queueServices_2015_12_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-queueServices\2015-12-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Quotas_2018_02_09()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Quotas\2018-02-09");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_RegionHealth_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-RegionHealth\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_ResourceHealth_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-ResourceHealth\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_ServiceHealth_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-ServiceHealth\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_shares_2015_12_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-shares\2015-12-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_SlbMuxInstance_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-SlbMuxInstance\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_storage_2015_12_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-storage\2015-12-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_storage_2019_08_08_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-storage\2019-08-08-preview");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_azsadmin_storageaccounts_2019_08_08_preview() '@odata.nextLink' causes problem.
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-storageaccounts\2019-08-08-preview");
-		//}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_StorageOperationResults_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-StorageOperationResults\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_StoragePool_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-StoragePool\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_StorageSubSystem_2018_10_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-StorageSubSystem\2018-10-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_StorageSystem_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-StorageSystem\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_tableServices_2015_12_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-tableServices\2015-12-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Update_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Update\2016-05-01");
-		}
-
-
-		//=============================
-
-		[Fact]
-		public void Test_azure_com_azsadmin_UpdateLocations_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-UpdateLocations\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_UpdateRuns_2016_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-UpdateRuns\2016-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_VirtualNetworks_2015_06_15()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-VirtualNetworks\2015-06-15");
-		}
-
-		[Fact]
-		public void Test_azure_com_azsadmin_Volume_2019_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azsadmin-Volume\2019-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azure_kusto_2019_11_09()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azure-kusto\2019-11-09");
-		}
-
-		[Fact]
-		public void Test_azure_com_azureactivedirectory_2017_04_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azureactivedirectory\2017-04-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_azuredata_2017_03_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azuredata\2017-03-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_azurestack_AzureStack_2017_06_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azurestack-AzureStack\2017-06-01");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_azurestack_Product_2017_06_01() has Uri as a component. Though I could rename it, but I would not bother this time.
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\azurestack-Product\2017-06-01");
-		//}
-
-
-		[Fact]
-		public void Test_azure_com_batch_BatchManagement_2019_08_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\batch-BatchManagement\2019-08-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_batch_BatchService_2019_08_01_10_0()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\batch-BatchService\2019-08-01.10.0");
-		}
-
-		//=========================================
-
-
-		[Fact]
-		public void Test_azure_com_batchai_BatchAI_2018_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\batchai-BatchAI\2018-05-01");
-		}
-
-
-
-		[Fact]
-		public void Test_azure_com_blockchain_2018_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\blockchain\2018-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_blueprint_assignmentOperation_2018_11_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\blueprint-assignmentOperation\2018-11-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_blueprint_blueprintAssignment_2018_11_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\blueprint-blueprintAssignment\2018-11-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_blueprint_blueprintDefinition_2018_11_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\blueprint-blueprintDefinition\2018-11-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_botservice_2018_07_12()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\botservice\2018-07-12");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_cdn_2019_12_31() @odata.type causes problem
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cdn\2019-12-31");
-		//}
-
-		[Fact]
-		public void Test_azure_com_cdn_cdnwebapplicationfirewall_2019_06_15_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cdn-cdnwebapplicationfirewall\2019-06-15-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_2017_04_18()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices\2017-04-18");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_AnomalyDetector_1_0()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-AnomalyDetector\1.0");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_AnomalyFinder_2_0()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-AnomalyFinder\2.0");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_BasicRegions_2017_08_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-BasicRegions\2017-08-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_ComputerVision_1_0()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-ComputerVision\1.0");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_ExtendedRegions_2017_08_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-ExtendedRegions\2017-08-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_Face_1_0()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-Face\1.0");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_FormRecognizerReceiptOcr_1_0_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-FormRecognizerReceiptOcr\1.0-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_InkRecognizer_1_0()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-InkRecognizer\1.0");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_LUIS_Runtime_3_0()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-LUIS-Runtime\3.0");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_LUIS_Runtime_3_0_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-LUIS-Runtime\3.0-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_Parameters_2017_08_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-Parameters\2017-08-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_Personalizer_v1_0()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-Personalizer\v1.0");
-		}
-
-		[Fact]
-		public void Test_azure_com_cognitiveservices_TextAnalytics_v3_0_preview_1()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cognitiveservices-TextAnalytics\v3.0-preview.1");
-		}
-
-		[Fact]
-		public void Test_azure_com_commerce_2015_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\commerce\2015-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_common_types_1_0()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\common-types\1.0");
-		}
-
-		[Fact]
-		public void Test_azure_com_compute_2019_07_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\compute\2019-07-01");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_compute_containerService_2017_01_31() ContainerServiceMasterProfile has casual enum 1, 3, 5. Good use of enum?
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\compute-containerService\2017-01-31");
-		//}
-
-		[Fact]
-		public void Test_azure_com_compute_disk_2019_07_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\compute-disk\2019-07-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_compute_gallery_2019_07_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\compute-gallery\2019-07-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_compute_runCommands_2019_07_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\compute-runCommands\2019-07-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_compute_skus_2019_04_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\compute-skus\2019-04-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_compute_swagger_2015_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\compute-swagger\2015-11-01");
-		}
-
-
-
-
-
-		//[Fact]
-		//public void Test_azure_com_consumption_2019_10_01() ReservationTransactionProperties looks invalid
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\consumption\2019-10-01");
-		//}
-
-		[Fact]
-		public void Test_azure_com_containerinstance_containerInstance_2018_10_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerinstance-containerInstance\2018-10-01");
-		}
-
-
-		[Fact]
-		public void Test_azure_com_containerregistry_2019_12_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerregistry\2019-12-01-preview");
-		}
-
-
-		[Fact]
-		public void Test_azure_com_containerregistry_containerregistry_build_2019_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerregistry-containerregistry_build\2019-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_containerregistry_containerregistry_scopemap_2019_05_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerregistry-containerregistry_scopemap\2019-05-01-preview");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_containerservice_containerService_2017_07_01() //funky use of enum?
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerservice-containerService\2017-07-01");
-		//}
-
-		[Fact]
-		public void Test_azure_com_containerservice_location_2019_08_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerservice-location\2019-08-01");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_containerservice_managedClusters_2020_01_01() //funky use of enum?
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerservice-managedClusters\2020-01-01");
-		//}
-
-		[Fact]
-		public void Test_azure_com_containerservice_openShiftManagedClusters_2019_09_30_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerservice-openShiftManagedClusters\2019-09-30-preview");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_containerservices_containerService_2017_07_01()//funky use of enum?
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerservices-containerService\2017-07-01");
-		//}
-
-		[Fact]
-		public void Test_azure_com_containerservices_location_2017_09_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerservices-location\2017-09-30");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_containerservices_managedClusters_2018_08_01_preview()//funky use of enum?
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerservices-managedClusters\2018-08-01-preview");
-		//}
-
-		[Fact]
-		public void Test_azure_com_containerservices_openShiftManagedClusters_2018_09_30_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\containerservices-openShiftManagedClusters\2018-09-30-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_cosmos_db_2019_12_12()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cosmos-db\2019-12-12");
-		}
-
-		[Fact]
-		public void Test_azure_com_cosmos_db_privateEndpointConnection_2019_08_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cosmos-db-privateEndpointConnection\2019-08-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_cosmos_db_privateLinkResources_2019_08_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cosmos-db-privateLinkResources\2019-08-01-preview");
-		}
-
-
-		[Fact]
-		public void Test_azure_com_cost_management_costmanagement_2019_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\cost-management-costmanagement\2019-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_customer_insights_2017_04_26()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\customer-insights\2017-04-26");
-		}
-
-		[Fact]
-		public void Test_azure_com_customerlockbox_2018_02_28_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\customerlockbox\2018-02-28-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_customproviders_2018_09_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\customproviders\2018-09-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_databox_2019_09_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\databox\2019-09-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_databoxedge_2019_08_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\databoxedge\2019-08-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_databricks_2018_04_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\databricks\2018-04-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datacatalog_2016_03_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datacatalog\2016-03-30");
-		}
-
-
-		[Fact]
-		public void Test_azure_com_datafactory_2018_06_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datafactory\2018-06-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datafactory_DataFlow_2018_06_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datafactory-DataFlow\2018-06-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datafactory_Dataset_2018_06_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datafactory-Dataset\2018-06-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datafactory_IntegrationRuntime_2018_06_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datafactory-IntegrationRuntime\2018-06-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datafactory_LinkedService_2018_06_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datafactory-LinkedService\2018-06-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datafactory_Pipeline_2018_06_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datafactory-Pipeline\2018-06-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datafactory_Trigger_2018_06_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datafactory-Trigger\2018-06-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datalake_analytics_account_2016_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datalake-analytics-account\2016-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datalake_analytics_catalog_2016_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datalake-analytics-catalog\2016-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datalake_analytics_job_2017_09_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datalake-analytics-job\2017-09-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_datalake_store_account_2016_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datalake-store-account\2016-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datalake_store_filesystem_2016_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datalake-store-filesystem\2016-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_datashare_DataShare_2019_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\datashare-DataShare\2019-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_deploymentmanager_2018_09_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\deploymentmanager\2018-09-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_deploymentmanager_2019_11_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\deploymentmanager\2019-11-01-preview");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_deviceprovisioningservices_iotdps_2018_01_22() $ref: '#/definitions/SharedAccessSignatureAuthorizationRule[AccessRightsDescription]'
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\deviceprovisioningservices-iotdps\2018-01-22");
-		//}
-
-		[Fact]
-		public void Test_azure_com_devops_2019_07_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\devops\2019-07-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_devspaces_2019_04_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\devspaces\2019-04-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_devtestlabs_DTL_2018_09_15()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\devtestlabs-DTL\2018-09-15");
-		}
-
-		[Fact]
-		public void Test_azure_com_digitaltwins_2020_03_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\digitaltwins\2020-03-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_dns_2018_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\dns\2018-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_domainservices_2020_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\domainservices\2020-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_dynamicstelemetry_2019_01_24()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\dynamicstelemetry\2019-01-24");
-		}
-
-		[Fact]
-		public void Test_azure_com_edgegateway_2019_03_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\edgegateway\2019-03-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_engagementfabric_EngagementFabric_2018_09_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\engagementfabric-EngagementFabric\2018-09-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_EnterpriseKnowledgeGraph_EnterpriseKnowledgeGraphSwagger_2018_12_03()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\EnterpriseKnowledgeGraph-EnterpriseKnowledgeGraphSwagger\2018-12-03");
-		}
-
-
-
-
-		[Fact]
-		public void Test_azure_com_eventgrid_AppConfiguration_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-AppConfiguration\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_ContainerRegistry_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-ContainerRegistry\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_EventGrid_2020_04_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-EventGrid\2020-04-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_EventHub_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-EventHub\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_IotHub_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-IotHub\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_KeyVault_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-KeyVault\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_MachineLearningServices_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-MachineLearningServices\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_Maps_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-Maps\2018-01-01");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_eventgrid_MediaServices_2018_01_01() not sure if I should support @odata.type?
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-MediaServices\2018-01-01");
-		//}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_Resources_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-Resources\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_ServiceBus_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-ServiceBus\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_SignalRService_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-SignalRService\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventgrid_Storage_2018_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventgrid-Storage\2018-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_eventhub_EventHub_preview_2018_01_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\eventhub-EventHub-preview\2018-01-01-preview");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_frontdoor_2020_01_01()not sure if I should support @odata.type?
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\frontdoor\2020-01-01");
-		//}
-
-		[Fact]
-		public void Test_azure_com_frontdoor_network_2020_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\frontdoor-network\2020-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_frontdoor_networkexperiment_2019_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\frontdoor-networkexperiment\2019-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_frontdoor_webapplicationfirewall_2019_10_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\frontdoor-webapplicationfirewall\2019-10-01");
-		}
-
-
-		[Fact]
-		public void Test_azure_com_hardwaresecuritymodules_dedicatedhsm_2018_10_31_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hardwaresecuritymodules-dedicatedhsm\2018-10-31-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_applications_2018_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-applications\2018-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_capabilities_2015_03_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-capabilities\2015-03-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_cluster_2015_03_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-cluster\2015-03-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_cluster_2018_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-cluster\2018-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_configurations_2018_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-configurations\2018-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_extensions_2018_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-extensions\2018-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_job_2018_11_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-job\2018-11-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_locations_2018_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-locations\2018-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_operations_2018_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-operations\2018-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_hdinsight_scriptActions_2018_06_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hdinsight-scriptActions\2018-06-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_healthcareapis_healthcare_apis_2019_09_16()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\healthcareapis-healthcare-apis\2019-09-16");
-		}
-
-		[Fact]
-		public void Test_azure_com_hybridcompute_HybridCompute_2019_12_12()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hybridcompute-HybridCompute\2019-12-12");
-		}
-
-		[Fact]
-		public void Test_azure_com_hybriddatamanager_hybriddata_2016_06_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\hybriddatamanager-hybriddata\2016-06-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_imagebuilder_2019_05_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\imagebuilder\2019-05-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_imds_2019_11_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\imds\2019-11-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_intune_2015_01_14_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\intune\2015-01-14-preview");
-		}
-
-		//===============
-
-		[Fact]
-		public void Test_azure_com_iotcentral_2018_09_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\iotcentral\2018-09-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_iothub_2019_11_04()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\iothub\2019-11-04");
-		}
-
-		[Fact]
-		public void Test_azure_com_iotspaces_2017_10_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\iotspaces\2017-10-01-preview");
-		}
-
-		//[Fact]
-		//public void Test_azure_com_keyvault_2019_09_01() invalid casual enum  resourceType eq 'Microsoft.KeyVault/vaults' in path '/subscriptions/{subscriptionId}/resources'
-		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\keyvault\2019-09-01");
-		//}
-
-		[Fact]
-		public void Test_azure_com_keyvault_providers_2019_09_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\keyvault-providers\2019-09-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_keyvault_secrets_2019_09_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\keyvault-secrets\2019-09-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_locationbasedservices_2017_01_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\locationbasedservices\2017-01-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_logic_2019_05_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\logic\2019-05-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_machinelearning_commitmentPlans_2016_05_01_preview()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\machinelearning-commitmentPlans\2016-05-01-preview");
-		}
-
-		[Fact]
-		public void Test_azure_com_machinelearning_webservices_2017_01_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\machinelearning-webservices\2017-01-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_machinelearning_workspaces_2019_10_01()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\machinelearning-workspaces\2019-10-01");
-		}
-
-		[Fact]
-		public void Test_azure_com_machinelearningservices_artifact_2019_09_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\machinelearningservices-artifact\2019-09-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_machinelearningservices_datastore_2019_09_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\machinelearningservices-datastore\2019-09-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_machinelearningservices_execution_2019_09_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\machinelearningservices-execution\2019-09-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_machinelearningservices_hyperdrive_2019_09_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\machinelearningservices-hyperdrive\2019-09-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_machinelearningservices_modelManagement_2019_09_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\machinelearningservices-modelManagement\2019-09-30");
-		}
-
-		[Fact]
-		public void Test_azure_com_machinelearningservices_runHistory_2019_09_30()
-		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\machinelearningservices-runHistory\2019-09-30");
-		}
-
-
-
-	}
+    public class ODAzureTests
+    {
+        readonly CSharpTestHelper helper;
+        public ODAzureTests(ITestOutputHelper output)
+        {
+            helper = new CSharpTestHelper(output);
+        }
+
+        [Fact]
+        public void Test_Addons()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\addons-Addons\2017-05-15");
+        }
+
+        [Fact]
+        public void Test_advisor()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\advisor\2020-01-01");
+        }
+
+        [Fact]
+        public void Test_alertsmanagementAlertsManagement()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\alertsmanagement-AlertsManagement\2019-03-01");
+        }
+
+        [Fact]
+        public void Test_alertsmanagementSmartDetectorAlertRulesApi()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\alertsmanagement-SmartDetectorAlertRulesApi\2019-06-01");
+        }
+
+        [Fact]
+        public void Test_analysisservices()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\analysisservices\2017-08-01");
+        }
+
+        [Fact]
+        public void Test_apimanagement()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\apimanagement\2019-01-01", new Settings() { UseSystemTextJson = true });
+        }
+
+        [Fact]
+        public void Test_appconfiguration()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\appconfiguration\2019-10-01");
+        }
+
+        [Fact]
+        public void Test_applicationinsightscomponentAnnotations_API()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\applicationinsights-componentAnnotations_API\2015-05-01");
+        }
+
+        [Fact]
+        public void Test_applicationinsightscomponentFeaturesAndPricing_API()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\applicationinsights-componentFeaturesAndPricing_API\2017-10-01");
+        }
+
+        [Fact]
+        public void Test_applicationinsightscomponentProactiveDetection_API()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\applicationinsights-componentProactiveDetection_API\2015-05-01");
+        }
+
+        //[Fact]
+        //public void Test_applicationinsightscomponents_API() it seems invalid. Nswag throws exceptions.
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\applicationinsights-components_API\2015-05-01");
+        //}
+
+        [Fact]
+        public void Test_appplatform()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\appplatform\2019-05-01-preview");
+        }
+
+        [Fact]
+        public void Test_attestation()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\attestation\2018-09-01-preview");
+        }
+
+        [Fact]
+        public void Test_authorization()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\authorization\2015-07-01");
+        }
+
+        [Fact]
+        public void Test_authorizationauthorizationProviderOperationsCalls()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\authorization-authorization-ProviderOperationsCalls\2018-01-01-preview");
+        }
+
+        [Fact]
+        public void Test_authorizationauthorizationRoleAssignmentsCalls()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\authorization-authorization-RoleAssignmentsCalls\2018-09-01-preview");
+        }
+
+        [Fact]
+        public void Test_authorizationauthorizationRoleDefinitionsCalls()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\authorization-authorization-RoleDefinitionsCalls\2018-01-01-preview");
+        }
+
+        [Fact]
+        public void Test_automationaccount()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-account\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_automationcertificate()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-certificate\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_automationconnection()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-connection\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_automationconnectionType()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-connectionType\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_automationdefinitions()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-definitions\2018-06-10");
+        }
+
+        [Fact]
+        public void Test_automationdscCompilationJob()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-dscCompilationJob\2018-01-15");
+        }
+
+        [Fact]
+        public void Test_automationdscNodeCounts()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-dscNodeCounts\2018-01-15");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_hybridRunbookWorkerGroup_2015_10_31()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-hybridRunbookWorkerGroup\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_job_2017_05_15_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-job\2017-05-15-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_jobSchedule_2015_10_31()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-jobSchedule\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_linkedWorkspace_2015_10_31()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-linkedWorkspace\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_module_2015_10_31()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-module\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_python2package_2018_06_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-python2package\2018-06-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_runbook_2018_06_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-runbook\2018-06-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_schedule_2015_10_31()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-schedule\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_softwareUpdateConfiguration_2017_05_15_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-softwareUpdateConfiguration\2017-05-15-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_softwareUpdateConfigurationMachineRun_2017_05_15_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-softwareUpdateConfigurationMachineRun\2017-05-15-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_softwareUpdateConfigurationRun_2017_05_15_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-softwareUpdateConfigurationRun\2017-05-15-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_sourceControl_2017_05_15_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-sourceControl\2017-05-15-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_sourceControlSyncJob_2017_05_15_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-sourceControlSyncJob\2017-05-15-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_sourceControlSyncJobStreams_2017_05_15_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-sourceControlSyncJobStreams\2017-05-15-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_variable_2015_10_31()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-variable\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_watcher_2015_10_31()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-watcher\2015-10-31");
+        }
+
+        [Fact]
+        public void Test_azure_com_automation_webhook_2015_10_31()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\automation-webhook\2015-10-31");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_azsadmin_AcquiredPlan_2015_11_01() invalid using parameters rather than definitions for components.
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-AcquiredPlan\2015-11-01");
+        //}
+
+        [Fact]
+        public void Test_azure_com_azsadmin_acquisitions_2019_08_08_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-acquisitions\2019-08-08-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_ActionPlan_2019_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-ActionPlan\2019-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_ActionPlanOperation_2019_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-ActionPlanOperation\2019-01-01");
+        }
+
+
+        [Fact]
+        public void Test_azure_com_azsadmin_ApplicationOperationResults_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-ApplicationOperationResults\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Backup_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Backup\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Backup_2018_09_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Backup\2018-09-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_blobServices_2015_12_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-blobServices\2015-12-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Commerce_2015_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Commerce\2015-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_CommerceAdmin_2015_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-CommerceAdmin\2015-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Compute_2015_12_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Compute\2015-12-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_ComputeOperationResults_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-ComputeOperationResults\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_DelegatedProvider_2015_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-DelegatedProvider\2015-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_DelegatedProviderOffer_2015_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-DelegatedProviderOffer\2015-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Deployment_2019_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Deployment\2019-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_DiskMigrationJobs_2018_07_30_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-DiskMigrationJobs\2018-07-30-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Disks_2018_07_30_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Disks\2018-07-30-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Drive_2019_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Drive\2019-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_EdgeGateway_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-EdgeGateway\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_EdgeGatewayPool_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-EdgeGatewayPool\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Fabric_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Fabric\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_FabricLocation_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-FabricLocation\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_farms_2015_12_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-farms\2015-12-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_FileContainer_2019_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-FileContainer\2019-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_FileShare_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-FileShare\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Gallery_2015_04_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Gallery\2015-04-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_InfraRole_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-InfraRole\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_InfraRoleInstance_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-InfraRoleInstance\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_InfrastructureInsights_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-InfrastructureInsights\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_KeyVault_2017_02_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-KeyVault\2017-02-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_LoadBalancers_2015_06_15()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-LoadBalancers\2015-06-15");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_LogicalNetwork_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-LogicalNetwork\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_LogicalSubnet_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-LogicalSubnet\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_MacAddressPool_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-MacAddressPool\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Manifest_2015_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Manifest\2015-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Network_2015_06_15()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Network\2015-06-15");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_NetworkOperationResults_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-NetworkOperationResults\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Offer_2015_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Offer\2015-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Operations_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Operations\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Product_2016_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Product\2016-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_ProductDeployment_2019_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-ProductDeployment\2019-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_ProductPackage_2019_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-ProductPackage\2019-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_ProductSecret_2019_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-ProductSecret\2019-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_PublicIpAddresses_2015_06_15()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-PublicIpAddresses\2015-06-15");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_queueServices_2015_12_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-queueServices\2015-12-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Quotas_2018_02_09()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Quotas\2018-02-09");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_RegionHealth_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-RegionHealth\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_ResourceHealth_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-ResourceHealth\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_ServiceHealth_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-ServiceHealth\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_shares_2015_12_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-shares\2015-12-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_SlbMuxInstance_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-SlbMuxInstance\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_storage_2015_12_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-storage\2015-12-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_storage_2019_08_08_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-storage\2019-08-08-preview");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_azsadmin_storageaccounts_2019_08_08_preview() '@odata.nextLink' causes problem.
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-storageaccounts\2019-08-08-preview");
+        //}
+
+        [Fact]
+        public void Test_azure_com_azsadmin_StorageOperationResults_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-StorageOperationResults\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_StoragePool_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-StoragePool\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_StorageSubSystem_2018_10_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-StorageSubSystem\2018-10-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_StorageSystem_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-StorageSystem\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_tableServices_2015_12_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-tableServices\2015-12-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Update_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Update\2016-05-01");
+        }
+
+
+        //=============================
+
+        [Fact]
+        public void Test_azure_com_azsadmin_UpdateLocations_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-UpdateLocations\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_UpdateRuns_2016_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-UpdateRuns\2016-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_VirtualNetworks_2015_06_15()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-VirtualNetworks\2015-06-15");
+        }
+
+        [Fact]
+        public void Test_azure_com_azsadmin_Volume_2019_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azsadmin-Volume\2019-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azure_kusto_2019_11_09()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azure-kusto\2019-11-09");
+        }
+
+        [Fact]
+        public void Test_azure_com_azureactivedirectory_2017_04_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azureactivedirectory\2017-04-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_azuredata_2017_03_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azuredata\2017-03-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_azurestack_AzureStack_2017_06_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azurestack-AzureStack\2017-06-01");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_azurestack_Product_2017_06_01() has Uri as a component. Though I could rename it, but I would not bother this time.
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\azurestack-Product\2017-06-01");
+        //}
+
+
+        [Fact]
+        public void Test_azure_com_batch_BatchManagement_2019_08_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\batch-BatchManagement\2019-08-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_batch_BatchService_2019_08_01_10_0()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\batch-BatchService\2019-08-01.10.0");
+        }
+
+        //=========================================
+
+
+        [Fact]
+        public void Test_azure_com_batchai_BatchAI_2018_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\batchai-BatchAI\2018-05-01");
+        }
+
+
+
+        [Fact]
+        public void Test_azure_com_blockchain_2018_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\blockchain\2018-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_blueprint_assignmentOperation_2018_11_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\blueprint-assignmentOperation\2018-11-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_blueprint_blueprintAssignment_2018_11_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\blueprint-blueprintAssignment\2018-11-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_blueprint_blueprintDefinition_2018_11_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\blueprint-blueprintDefinition\2018-11-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_botservice_2018_07_12()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\botservice\2018-07-12");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_cdn_2019_12_31() @odata.type causes problem
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cdn\2019-12-31");
+        //}
+
+        [Fact]
+        public void Test_azure_com_cdn_cdnwebapplicationfirewall_2019_06_15_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cdn-cdnwebapplicationfirewall\2019-06-15-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_2017_04_18()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices\2017-04-18");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_AnomalyDetector_1_0()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-AnomalyDetector\1.0");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_AnomalyFinder_2_0()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-AnomalyFinder\2.0");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_BasicRegions_2017_08_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-BasicRegions\2017-08-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_ComputerVision_1_0()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-ComputerVision\1.0");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_ExtendedRegions_2017_08_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-ExtendedRegions\2017-08-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_Face_1_0()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-Face\1.0");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_FormRecognizerReceiptOcr_1_0_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-FormRecognizerReceiptOcr\1.0-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_InkRecognizer_1_0()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-InkRecognizer\1.0");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_LUIS_Runtime_3_0()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-LUIS-Runtime\3.0");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_LUIS_Runtime_3_0_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-LUIS-Runtime\3.0-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_Parameters_2017_08_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-Parameters\2017-08-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_Personalizer_v1_0()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-Personalizer\v1.0");
+        }
+
+        [Fact]
+        public void Test_azure_com_cognitiveservices_TextAnalytics_v3_0_preview_1()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cognitiveservices-TextAnalytics\v3.0-preview.1");
+        }
+
+        [Fact]
+        public void Test_azure_com_commerce_2015_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\commerce\2015-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_common_types_1_0()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\common-types\1.0");
+        }
+
+        [Fact]
+        public void Test_azure_com_compute_2019_07_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\compute\2019-07-01");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_compute_containerService_2017_01_31() ContainerServiceMasterProfile has casual enum 1, 3, 5. Good use of enum?
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\compute-containerService\2017-01-31");
+        //}
+
+        [Fact]
+        public void Test_azure_com_compute_disk_2019_07_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\compute-disk\2019-07-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_compute_gallery_2019_07_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\compute-gallery\2019-07-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_compute_runCommands_2019_07_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\compute-runCommands\2019-07-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_compute_skus_2019_04_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\compute-skus\2019-04-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_compute_swagger_2015_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\compute-swagger\2015-11-01");
+        }
+
+
+
+
+
+        //[Fact]
+        //public void Test_azure_com_consumption_2019_10_01() ReservationTransactionProperties looks invalid
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\consumption\2019-10-01");
+        //}
+
+        [Fact]
+        public void Test_azure_com_containerinstance_containerInstance_2018_10_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerinstance-containerInstance\2018-10-01");
+        }
+
+
+        [Fact]
+        public void Test_azure_com_containerregistry_2019_12_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerregistry\2019-12-01-preview");
+        }
+
+
+        [Fact]
+        public void Test_azure_com_containerregistry_containerregistry_build_2019_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerregistry-containerregistry_build\2019-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_containerregistry_containerregistry_scopemap_2019_05_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerregistry-containerregistry_scopemap\2019-05-01-preview");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_containerservice_containerService_2017_07_01() //funky use of enum?
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerservice-containerService\2017-07-01");
+        //}
+
+        [Fact]
+        public void Test_azure_com_containerservice_location_2019_08_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerservice-location\2019-08-01");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_containerservice_managedClusters_2020_01_01() //funky use of enum?
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerservice-managedClusters\2020-01-01");
+        //}
+
+        [Fact]
+        public void Test_azure_com_containerservice_openShiftManagedClusters_2019_09_30_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerservice-openShiftManagedClusters\2019-09-30-preview");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_containerservices_containerService_2017_07_01()//funky use of enum?
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerservices-containerService\2017-07-01");
+        //}
+
+        [Fact]
+        public void Test_azure_com_containerservices_location_2017_09_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerservices-location\2017-09-30");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_containerservices_managedClusters_2018_08_01_preview()//funky use of enum?
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerservices-managedClusters\2018-08-01-preview");
+        //}
+
+        [Fact]
+        public void Test_azure_com_containerservices_openShiftManagedClusters_2018_09_30_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\containerservices-openShiftManagedClusters\2018-09-30-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_cosmos_db_2019_12_12()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cosmos-db\2019-12-12");
+        }
+
+        [Fact]
+        public void Test_azure_com_cosmos_db_privateEndpointConnection_2019_08_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cosmos-db-privateEndpointConnection\2019-08-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_cosmos_db_privateLinkResources_2019_08_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cosmos-db-privateLinkResources\2019-08-01-preview");
+        }
+
+
+        [Fact]
+        public void Test_azure_com_cost_management_costmanagement_2019_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\cost-management-costmanagement\2019-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_customer_insights_2017_04_26()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\customer-insights\2017-04-26");
+        }
+
+        [Fact]
+        public void Test_azure_com_customerlockbox_2018_02_28_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\customerlockbox\2018-02-28-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_customproviders_2018_09_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\customproviders\2018-09-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_databox_2019_09_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\databox\2019-09-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_databoxedge_2019_08_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\databoxedge\2019-08-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_databricks_2018_04_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\databricks\2018-04-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datacatalog_2016_03_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datacatalog\2016-03-30");
+        }
+
+
+        [Fact]
+        public void Test_azure_com_datafactory_2018_06_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datafactory\2018-06-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datafactory_DataFlow_2018_06_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datafactory-DataFlow\2018-06-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datafactory_Dataset_2018_06_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datafactory-Dataset\2018-06-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datafactory_IntegrationRuntime_2018_06_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datafactory-IntegrationRuntime\2018-06-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datafactory_LinkedService_2018_06_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datafactory-LinkedService\2018-06-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datafactory_Pipeline_2018_06_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datafactory-Pipeline\2018-06-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datafactory_Trigger_2018_06_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datafactory-Trigger\2018-06-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datalake_analytics_account_2016_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datalake-analytics-account\2016-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datalake_analytics_catalog_2016_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datalake-analytics-catalog\2016-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datalake_analytics_job_2017_09_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datalake-analytics-job\2017-09-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_datalake_store_account_2016_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datalake-store-account\2016-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datalake_store_filesystem_2016_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datalake-store-filesystem\2016-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_datashare_DataShare_2019_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\datashare-DataShare\2019-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_deploymentmanager_2018_09_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\deploymentmanager\2018-09-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_deploymentmanager_2019_11_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\deploymentmanager\2019-11-01-preview");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_deviceprovisioningservices_iotdps_2018_01_22() $ref: '#/definitions/SharedAccessSignatureAuthorizationRule[AccessRightsDescription]'
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\deviceprovisioningservices-iotdps\2018-01-22");
+        //}
+
+        [Fact]
+        public void Test_azure_com_devops_2019_07_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\devops\2019-07-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_devspaces_2019_04_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\devspaces\2019-04-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_devtestlabs_DTL_2018_09_15()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\devtestlabs-DTL\2018-09-15");
+        }
+
+        [Fact]
+        public void Test_azure_com_digitaltwins_2020_03_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\digitaltwins\2020-03-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_dns_2018_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\dns\2018-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_domainservices_2020_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\domainservices\2020-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_dynamicstelemetry_2019_01_24()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\dynamicstelemetry\2019-01-24");
+        }
+
+        [Fact]
+        public void Test_azure_com_edgegateway_2019_03_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\edgegateway\2019-03-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_engagementfabric_EngagementFabric_2018_09_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\engagementfabric-EngagementFabric\2018-09-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_EnterpriseKnowledgeGraph_EnterpriseKnowledgeGraphSwagger_2018_12_03()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\EnterpriseKnowledgeGraph-EnterpriseKnowledgeGraphSwagger\2018-12-03");
+        }
+
+
+
+
+        [Fact]
+        public void Test_azure_com_eventgrid_AppConfiguration_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-AppConfiguration\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_ContainerRegistry_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-ContainerRegistry\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_EventGrid_2020_04_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-EventGrid\2020-04-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_EventHub_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-EventHub\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_IotHub_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-IotHub\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_KeyVault_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-KeyVault\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_MachineLearningServices_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-MachineLearningServices\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_Maps_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-Maps\2018-01-01");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_eventgrid_MediaServices_2018_01_01() not sure if I should support @odata.type?
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-MediaServices\2018-01-01");
+        //}
+
+        [Fact]
+        public void Test_azure_com_eventgrid_Resources_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-Resources\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_ServiceBus_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-ServiceBus\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_SignalRService_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-SignalRService\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventgrid_Storage_2018_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventgrid-Storage\2018-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_eventhub_EventHub_preview_2018_01_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\eventhub-EventHub-preview\2018-01-01-preview");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_frontdoor_2020_01_01()not sure if I should support @odata.type?
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\frontdoor\2020-01-01");
+        //}
+
+        [Fact]
+        public void Test_azure_com_frontdoor_network_2020_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\frontdoor-network\2020-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_frontdoor_networkexperiment_2019_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\frontdoor-networkexperiment\2019-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_frontdoor_webapplicationfirewall_2019_10_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\frontdoor-webapplicationfirewall\2019-10-01");
+        }
+
+
+        [Fact]
+        public void Test_azure_com_hardwaresecuritymodules_dedicatedhsm_2018_10_31_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hardwaresecuritymodules-dedicatedhsm\2018-10-31-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_applications_2018_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-applications\2018-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_capabilities_2015_03_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-capabilities\2015-03-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_cluster_2015_03_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-cluster\2015-03-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_cluster_2018_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-cluster\2018-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_configurations_2018_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-configurations\2018-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_extensions_2018_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-extensions\2018-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_job_2018_11_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-job\2018-11-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_locations_2018_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-locations\2018-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_operations_2018_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-operations\2018-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_hdinsight_scriptActions_2018_06_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hdinsight-scriptActions\2018-06-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_healthcareapis_healthcare_apis_2019_09_16()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\healthcareapis-healthcare-apis\2019-09-16");
+        }
+
+        [Fact]
+        public void Test_azure_com_hybridcompute_HybridCompute_2019_12_12()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hybridcompute-HybridCompute\2019-12-12");
+        }
+
+        [Fact]
+        public void Test_azure_com_hybriddatamanager_hybriddata_2016_06_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\hybriddatamanager-hybriddata\2016-06-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_imagebuilder_2019_05_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\imagebuilder\2019-05-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_imds_2019_11_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\imds\2019-11-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_intune_2015_01_14_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\intune\2015-01-14-preview");
+        }
+
+        //===============
+
+        [Fact]
+        public void Test_azure_com_iotcentral_2018_09_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\iotcentral\2018-09-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_iothub_2019_11_04()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\iothub\2019-11-04");
+        }
+
+        [Fact]
+        public void Test_azure_com_iotspaces_2017_10_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\iotspaces\2017-10-01-preview");
+        }
+
+        //[Fact]
+        //public void Test_azure_com_keyvault_2019_09_01() invalid casual enum  resourceType eq 'Microsoft.KeyVault/vaults' in path '/subscriptions/{subscriptionId}/resources'
+        //{
+        //	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\keyvault\2019-09-01");
+        //}
+
+        [Fact]
+        public void Test_azure_com_keyvault_providers_2019_09_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\keyvault-providers\2019-09-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_keyvault_secrets_2019_09_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\keyvault-secrets\2019-09-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_locationbasedservices_2017_01_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\locationbasedservices\2017-01-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_logic_2019_05_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\logic\2019-05-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_machinelearning_commitmentPlans_2016_05_01_preview()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\machinelearning-commitmentPlans\2016-05-01-preview");
+        }
+
+        [Fact]
+        public void Test_azure_com_machinelearning_webservices_2017_01_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\machinelearning-webservices\2017-01-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_machinelearning_workspaces_2019_10_01()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\machinelearning-workspaces\2019-10-01");
+        }
+
+        [Fact]
+        public void Test_azure_com_machinelearningservices_artifact_2019_09_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\machinelearningservices-artifact\2019-09-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_machinelearningservices_datastore_2019_09_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\machinelearningservices-datastore\2019-09-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_machinelearningservices_execution_2019_09_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\machinelearningservices-execution\2019-09-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_machinelearningservices_hyperdrive_2019_09_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\machinelearningservices-hyperdrive\2019-09-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_machinelearningservices_modelManagement_2019_09_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\machinelearningservices-modelManagement\2019-09-30");
+        }
+
+        [Fact]
+        public void Test_azure_com_machinelearningservices_runHistory_2019_09_30()
+        {
+            helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\machinelearningservices-runHistory\2019-09-30");
+        }
+
+
+
+    }
 }

--- a/Tests/CsSwagger2Tests/ODAzureTests2.cs
+++ b/Tests/CsSwagger2Tests/ODAzureTests2.cs
@@ -15,385 +15,385 @@ namespace SwagTests
 		[Fact]
 		public void Test_azure_com_maintenance_Maintenance_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\maintenance-Maintenance\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\maintenance-Maintenance\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_managednetwork_managedNetwork_2019_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\managednetwork-managedNetwork\2019-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\managednetwork-managedNetwork\2019-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_managedservices_2019_09_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\managedservices\2019-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\managedservices\2019-09-01");
 		}
 
 
 		[Fact]
 		public void Test_azure_com_managementpartner_ManagementPartner_2018_02_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\managementpartner-ManagementPartner\2018-02-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\managementpartner-ManagementPartner\2018-02-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_maps_maps_management_2020_02_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\maps-maps-management\2020-02-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\maps-maps-management\2020-02-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_mariadb_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mariadb\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mariadb\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_mariadb_DataEncryptionKeys_2020_01_01_privatepreview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mariadb-DataEncryptionKeys\2020-01-01-privatepreview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mariadb-DataEncryptionKeys\2020-01-01-privatepreview");
 		}
 
 		[Fact]
 		public void Test_azure_com_mariadb_PerformanceRecommendations_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mariadb-PerformanceRecommendations\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mariadb-PerformanceRecommendations\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_mariadb_PrivateEndpointConnections_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mariadb-PrivateEndpointConnections\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mariadb-PrivateEndpointConnections\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_mariadb_PrivateLinkResources_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mariadb-PrivateLinkResources\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mariadb-PrivateLinkResources\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_mariadb_QueryPerformanceInsights_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mariadb-QueryPerformanceInsights\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mariadb-QueryPerformanceInsights\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_marketplace_Marketplace_2020_01_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\marketplace-Marketplace\2020-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\marketplace-Marketplace\2020-01-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_marketplaceordering_Agreements_2015_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\marketplaceordering-Agreements\2015-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\marketplaceordering-Agreements\2015-06-01");
 		}
 
 
 		[Fact]
 		public void Test_azure_com_mediaservices_Common_2018_07_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mediaservices-Common\2018-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mediaservices-Common\2018-07-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_mediaservices_media_2015_10_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mediaservices-media\2015-10-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mediaservices-media\2015-10-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_migrate_2019_10_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\migrate\2019-10-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\migrate\2019-10-01");
 		}
 
 
 		[Fact]
 		public void Test_azure_com_mobileengagement_mobile_engagement_2014_12_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mobileengagement-mobile-engagement\2014-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mobileengagement-mobile-engagement\2014-12-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_actionGroups_API_2019_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-actionGroups_API\2019-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-actionGroups_API\2019-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_activityLogAlerts_API_2017_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-activityLogAlerts_API\2017-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-activityLogAlerts_API\2017-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_activityLogs_API_2015_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-activityLogs_API\2015-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-activityLogs_API\2015-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_alertRulesIncidents_API_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-alertRulesIncidents_API\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-alertRulesIncidents_API\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_alertRules_API_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-alertRules_API\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-alertRules_API\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_autoscale_API_2015_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-autoscale_API\2015-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-autoscale_API\2015-04-01");
 		}
 
 
 		[Fact]
 		public void Test_azure_com_monitor_baseline_API_2018_09_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-baseline_API\2018-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-baseline_API\2018-09-01");
 		}
 
 
 		[Fact]
 		public void Test_azure_com_monitor_calculateBaseline_API_2018_09_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-calculateBaseline_API\2018-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-calculateBaseline_API\2018-09-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_eventCategories_API_2015_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-eventCategories_API\2015-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-eventCategories_API\2015-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_guestDiagnosticSettingsAssociation_API_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-guestDiagnosticSettingsAssociation_API\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-guestDiagnosticSettingsAssociation_API\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_guestDiagnosticSettings_API_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-guestDiagnosticSettings_API\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-guestDiagnosticSettings_API\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_logProfiles_API_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-logProfiles_API\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-logProfiles_API\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_metricAlert_API_2018_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-metricAlert_API\2018-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-metricAlert_API\2018-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_metricBaselines_API_2019_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-metricBaselines_API\2019-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-metricBaselines_API\2019-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_metricDefinitions_API_2018_01_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-metricDefinitions_API\2018-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-metricDefinitions_API\2018-01-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_metricNamespaces_API_2017_12_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-metricNamespaces_API\2017-12-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-metricNamespaces_API\2017-12-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_metricsCreate_API_2018_09_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-metricsCreate_API\2018-09-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-metricsCreate_API\2018-09-01-preview");
 		}
 
 		//[Fact]
 		//public void Test_azure_com_monitor_metrics_API_2018_01_01() Response has property number/int32 which does not match swagger 2.0 data types.
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-metrics_API\2018-01-01");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-metrics_API\2018-01-01");
 		//}
 
 		[Fact]
 		public void Test_azure_com_monitor_operations_API_2015_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-operations_API\2015-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-operations_API\2015-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_privateLinkScopes_API_2019_10_17_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-privateLinkScopes_API\2019-10-17-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-privateLinkScopes_API\2019-10-17-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_scheduledQueryRule_API_2018_04_16()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-scheduledQueryRule_API\2018-04-16");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-scheduledQueryRule_API\2018-04-16");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_serviceDiagnosticsSettings_API_2016_09_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-serviceDiagnosticsSettings_API\2016-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-serviceDiagnosticsSettings_API\2016-09-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_subscriptionDiagnosticsSettings_API_2017_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-subscriptionDiagnosticsSettings_API\2017-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-subscriptionDiagnosticsSettings_API\2017-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_tenantActivityLogs_API_2015_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-tenantActivityLogs_API\2015-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-tenantActivityLogs_API\2015-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_monitor_vmInsightsOnboarding_API_2018_11_27_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\monitor-vmInsightsOnboarding_API\2018-11-27-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\monitor-vmInsightsOnboarding_API\2018-11-27-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_msi_ManagedIdentity_2018_11_30()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\msi-ManagedIdentity\2018-11-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\msi-ManagedIdentity\2018-11-30");
 		}
 
 		[Fact]
 		public void Test_azure_com_mysql_2017_12_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mysql\2017-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mysql\2017-12-01");
 		}
 
 
 		[Fact]
 		public void Test_azure_com_mysql_DataEncryptionKeys_2020_01_01_privatepreview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mysql-DataEncryptionKeys\2020-01-01-privatepreview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mysql-DataEncryptionKeys\2020-01-01-privatepreview");
 		}
 
 		[Fact]
 		public void Test_azure_com_mysql_PerformanceRecommendations_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mysql-PerformanceRecommendations\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mysql-PerformanceRecommendations\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_mysql_PrivateEndpointConnections_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mysql-PrivateEndpointConnections\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mysql-PrivateEndpointConnections\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_mysql_PrivateLinkResources_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mysql-PrivateLinkResources\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mysql-PrivateLinkResources\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_mysql_QueryPerformanceInsights_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\mysql-QueryPerformanceInsights\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\mysql-QueryPerformanceInsights\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_netapp_2019_11_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\netapp\2019-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\netapp\2019-11-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_2019_11_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network\2019-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network\2019-11-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_applicationSecurityGroup_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-applicationSecurityGroup\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-applicationSecurityGroup\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_availableDelegations_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-availableDelegations\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-availableDelegations\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_availableServiceAliases_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-availableServiceAliases\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-availableServiceAliases\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_azureFirewall_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-azureFirewall\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-azureFirewall\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_azureFirewallFqdnTag_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-azureFirewallFqdnTag\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-azureFirewallFqdnTag\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_bastionHost_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-bastionHost\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-bastionHost\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_checkDnsAvailability_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-checkDnsAvailability\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-checkDnsAvailability\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_ddosCustomPolicy_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-ddosCustomPolicy\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-ddosCustomPolicy\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_ddosProtectionPlan_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-ddosProtectionPlan\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-ddosProtectionPlan\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_endpointService_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-endpointService\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-endpointService\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_expressRouteCircuit_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-expressRouteCircuit\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-expressRouteCircuit\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_expressRouteCrossConnection_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-expressRouteCrossConnection\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-expressRouteCrossConnection\2019-08-01");
 		}
 
 		//=======================
@@ -402,31 +402,31 @@ namespace SwagTests
 		[Fact]
 		public void Test_azure_com_network_expressRouteGateway_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-expressRouteGateway\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-expressRouteGateway\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_expressRoutePort_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-expressRoutePort\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-expressRoutePort\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_network_firewallPolicy_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-firewallPolicy\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-firewallPolicy\2019-08-01");
 		}
 
 		//[Fact]
 		//public void Test_azure_com_network_interfaceEndpoint_2019_02_01()InterfaceEndpointProperties has some nested definition to external definitions?
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-interfaceEndpoint\2019-02-01");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-interfaceEndpoint\2019-02-01");
 		//}
 
 		[Fact]
 		public void Test_azure_com_network_ipGroups_2019_11_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\network-ipGroups\2019-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\network-ipGroups\2019-11-01");
 		}
 
 		//======================
@@ -434,67 +434,67 @@ namespace SwagTests
 		[Fact]
 		public void Test_azure_com_redis_2019_07_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\redis\2019-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\redis\2019-07-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_relay_2017_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\relay\2017-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\relay\2017-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_reservations_quota_2019_07_19_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\reservations-quota\2019-07-19-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\reservations-quota\2019-07-19-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_resourcegraph_graphquery_2018_09_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resourcegraph-graphquery\2018-09-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resourcegraph-graphquery\2018-09-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_resourcehealth_2017_07_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resourcehealth\2017-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resourcehealth\2017-07-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_resourcehealth_ResourceHealth_2018_07_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resourcehealth-ResourceHealth\2018-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resourcehealth-ResourceHealth\2018-07-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_2019_10_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources\2019-10-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources\2019-10-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_deploymentScripts_2019_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-deploymentScripts\2019-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-deploymentScripts\2019-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_features_2015_12_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-features\2015-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-features\2015-12-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_links_2016_09_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-links\2016-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-links\2016-09-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_locks_2016_09_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-locks\2016-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-locks\2016-09-01");
 		}
 
 		//======================
@@ -502,1047 +502,1047 @@ namespace SwagTests
 		[Fact]
 		public void Test_azure_com_resources_managedapplications_2019_07_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-managedapplications\2019-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-managedapplications\2019-07-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_management_2017_08_31_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-management\2017-08-31-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-management\2017-08-31-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_policy_2016_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-policy\2016-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-policy\2016-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_policyAssignments_2019_09_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-policyAssignments\2019-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-policyAssignments\2019-09-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_policyDefinitions_2019_09_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-policyDefinitions\2019-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-policyDefinitions\2019-09-01");
 		}
 		[Fact]
 		public void Test_azure_com_resources_policySetDefinitions_2019_09_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-policySetDefinitions\2019-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-policySetDefinitions\2019-09-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_resources_subscriptions_2019_11_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\resources-subscriptions\2019-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\resources-subscriptions\2019-11-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_scheduler_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\scheduler\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\scheduler\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_search_2019_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\search\2019-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\search\2019-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_2017_08_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security\2017-08-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security\2017-08-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_adaptiveNetworkHardenings_2015_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-adaptiveNetworkHardenings\2015-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-adaptiveNetworkHardenings\2015-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_advancedThreatProtectionSettings_2019_01_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-advancedThreatProtectionSettings\2019-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-advancedThreatProtectionSettings\2019-01-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_alerts_2019_01_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-alerts\2019-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-alerts\2019-01-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_allowedConnections_2015_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-allowedConnections\2015-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-allowedConnections\2015-06-01-preview");
 		}
 
 
 		[Fact]
 		public void Test_azure_com_security_assessmentMetadata_2020_01_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-assessmentMetadata\2020-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-assessmentMetadata\2020-01-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_autoProvisioningSettings_2017_08_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-autoProvisioningSettings\2017-08-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-autoProvisioningSettings\2017-08-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_complianceResults_2017_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-complianceResults\2017-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-complianceResults\2017-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_compliances_2017_08_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-compliances\2017-08-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-compliances\2017-08-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_deviceSecurityGroups_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-deviceSecurityGroups\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-deviceSecurityGroups\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_discoveredSecuritySolutions_2015_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-discoveredSecuritySolutions\2015-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-discoveredSecuritySolutions\2015-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_externalSecuritySolutions_2015_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-externalSecuritySolutions\2015-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-externalSecuritySolutions\2015-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_informationProtectionPolicies_2017_08_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-informationProtectionPolicies\2017-08-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-informationProtectionPolicies\2017-08-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_iotSecuritySolutionAnalytics_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-iotSecuritySolutionAnalytics\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-iotSecuritySolutionAnalytics\2019-08-01");
 		}
 
 		//[Fact]
 		//public void Test_azure_com_security_jitNetworkAccessPolicies_2015_06_01_preview() //bad def
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-jitNetworkAccessPolicies\2015-06-01-preview");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-jitNetworkAccessPolicies\2015-06-01-preview");
 		//}
 
 		[Fact]
 		public void Test_azure_com_security_locations_2015_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-locations\2015-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-locations\2015-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_operations_2015_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-operations\2015-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-operations\2015-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_pricings_2018_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-pricings\2018-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-pricings\2018-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_regulatoryCompliance_2019_01_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-regulatoryCompliance\2019-01-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-regulatoryCompliance\2019-01-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_securityContacts_2017_08_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-securityContacts\2017-08-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-securityContacts\2017-08-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_serverVulnerabilityAssessments_2019_01_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-serverVulnerabilityAssessments\2019-01-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-serverVulnerabilityAssessments\2019-01-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_subAssessments_2019_01_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-subAssessments\2019-01-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-subAssessments\2019-01-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_tasks_2015_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-tasks\2015-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-tasks\2015-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_topologies_2015_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-topologies\2015-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-topologies\2015-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_types_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-types\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-types\1.0");
 		}
 
 		[Fact]
 		public void Test_azure_com_security_workspaceSettings_2017_08_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\security-workspaceSettings\2017-08-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\security-workspaceSettings\2017-08-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_securityinsights_SecurityInsights_2020_01_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\securityinsights-SecurityInsights\2020-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\securityinsights-SecurityInsights\2020-01-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_serialconsole_2018_05_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\serialconsole\2018-05-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\serialconsole\2018-05-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_servermanagement_2016_07_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\servermanagement\2016-07-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\servermanagement\2016-07-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_service_map_arm_service_map_2015_11_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\service-map-arm-service-map\2015-11-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\service-map-arm-service-map\2015-11-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_servicebus_2017_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\servicebus\2017-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\servicebus\2017-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_servicebus_servicebus_preview_2018_01_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\servicebus-servicebus-preview\2018-01-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\servicebus-servicebus-preview\2018-01-01-preview");
 		}
 
 		//[Fact]
 		//public void Test_azure_com_servicefabric_7_0_0_42()
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\servicefabric\7.0.0.42");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\servicefabric\7.0.0.42");
 		//}
 
 
 		[Fact]
 		public void Test_azure_com_servicefabric_application_2019_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\servicefabric-application\2019-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\servicefabric-application\2019-03-01");
 		}
 
 
 		[Fact]
 		public void Test_azure_com_servicefabric_cluster_2019_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\servicefabric-cluster\2019-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\servicefabric-cluster\2019-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_servicefabric_cluster_2019_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\servicefabric-cluster\2019-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\servicefabric-cluster\2019-03-01-preview");
 		}
 
 		//[Fact]
 		//public void Test_azure_com_servicefabricmesh_2018_09_01_preview()
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\servicefabricmesh\2018-09-01-preview");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\servicefabricmesh\2018-09-01-preview");
 		//}
 
 		[Fact]
 		public void Test_azure_com_signalr_2018_10_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\signalr\2018-10-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\signalr\2018-10-01");
 		}
 
 		//[Fact]
 		//public void Test_azure_com_softwareplan_2019_12_01()
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\softwareplan\2019-12-01");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\softwareplan\2019-12-01");
 		//}
 
 		[Fact]
 		public void Test_azure_com_sql_advisors_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-advisors\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-advisors\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_backupLongTermRetentionPolicies_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-backupLongTermRetentionPolicies\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-backupLongTermRetentionPolicies\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_backupLongTermRetentionVaults_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-backupLongTermRetentionVaults\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-backupLongTermRetentionVaults\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_backups_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-backups\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-backups\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_blobAuditing_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-blobAuditing\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-blobAuditing\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_blobAuditingPolicies_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-blobAuditingPolicies\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-blobAuditingPolicies\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_cancelOperations_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-cancelOperations\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-cancelOperations\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_cancelPoolOperations_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-cancelPoolOperations\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-cancelPoolOperations\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_capabilities_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-capabilities\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-capabilities\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_checkNameAvailability_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-checkNameAvailability\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-checkNameAvailability\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_connectionPolicies_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-connectionPolicies\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-connectionPolicies\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_databaseAutomaticTuning_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-databaseAutomaticTuning\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-databaseAutomaticTuning\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_databases_2019_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-databases\2019-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-databases\2019-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_DatabaseSchema_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-DatabaseSchema\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-DatabaseSchema\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_DatabaseSecurityAlertPolicies_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-DatabaseSecurityAlertPolicies\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-DatabaseSecurityAlertPolicies\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_databaseVulnerabilityAssessmentBaselines_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-databaseVulnerabilityAssessmentBaselines\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-databaseVulnerabilityAssessmentBaselines\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_databaseVulnerabilityAssessments_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-databaseVulnerabilityAssessments\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-databaseVulnerabilityAssessments\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_databaseVulnerabilityAssessmentScans_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-databaseVulnerabilityAssessmentScans\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-databaseVulnerabilityAssessmentScans\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_dataMasking_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-dataMasking\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-dataMasking\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_dataWarehouseUserActivities_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-dataWarehouseUserActivities\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-dataWarehouseUserActivities\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_disasterRecoveryConfigurations_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-disasterRecoveryConfigurations\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-disasterRecoveryConfigurations\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_elasticPools_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-elasticPools\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-elasticPools\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_elasticPools_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-elasticPools\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-elasticPools\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_encryptionProtectors_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-encryptionProtectors\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-encryptionProtectors\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_FailoverDatabases_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-FailoverDatabases\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-FailoverDatabases\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_FailoverElasticPools_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-FailoverElasticPools\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-FailoverElasticPools\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_failoverGroups_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-failoverGroups\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-failoverGroups\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_firewallRules_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-firewallRules\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-firewallRules\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_geoBackupPolicies_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-geoBackupPolicies\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-geoBackupPolicies\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_importExport_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-importExport\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-importExport\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_instanceFailoverGroups_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-instanceFailoverGroups\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-instanceFailoverGroups\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_instancePools_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-instancePools\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-instancePools\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_jobs_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-jobs\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-jobs\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_longTermRetention_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-longTermRetention\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-longTermRetention\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ManagedBackupShortTermRetention_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ManagedBackupShortTermRetention\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ManagedBackupShortTermRetention\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_managedDatabases_2019_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-managedDatabases\2019-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-managedDatabases\2019-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ManagedDatabaseSchema_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ManagedDatabaseSchema\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ManagedDatabaseSchema\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ManagedDatabaseSecurityAlertPolicies_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ManagedDatabaseSecurityAlertPolicies\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ManagedDatabaseSecurityAlertPolicies\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_managedDatabaseSensitivityLabels_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-managedDatabaseSensitivityLabels\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-managedDatabaseSensitivityLabels\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_managedDatabaseVulnerabilityAssesmentRuleBaselines_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-managedDatabaseVulnerabilityAssesmentRuleBaselines\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-managedDatabaseVulnerabilityAssesmentRuleBaselines\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_managedDatabaseVulnerabilityAssessments_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-managedDatabaseVulnerabilityAssessments\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-managedDatabaseVulnerabilityAssessments\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_managedDatabaseVulnerabilityAssessmentScans_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-managedDatabaseVulnerabilityAssessmentScans\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-managedDatabaseVulnerabilityAssessmentScans\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_managedInstanceAdministrators_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-managedInstanceAdministrators\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-managedInstanceAdministrators\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ManagedInstanceEncryptionProtectors_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ManagedInstanceEncryptionProtectors\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ManagedInstanceEncryptionProtectors\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ManagedInstanceKeys_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ManagedInstanceKeys\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ManagedInstanceKeys\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_managedInstanceOperations_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-managedInstanceOperations\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-managedInstanceOperations\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_managedInstances_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-managedInstances\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-managedInstances\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ManagedInstanceTdeCertificates_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ManagedInstanceTdeCertificates\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ManagedInstanceTdeCertificates\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ManagedInstanceVulnerabilityAssessments_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ManagedInstanceVulnerabilityAssessments\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ManagedInstanceVulnerabilityAssessments\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ManagedRestorableDroppedDatabaseBackupShortTermRetenion_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ManagedRestorableDroppedDatabaseBackupShortTermRetenion\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ManagedRestorableDroppedDatabaseBackupShortTermRetenion\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ManagedServerSecurityAlertPolicy_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ManagedServerSecurityAlertPolicy\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ManagedServerSecurityAlertPolicy\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_metrics_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-metrics\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-metrics\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_operations_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-operations\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-operations\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_PrivateEndpointConnections_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-PrivateEndpointConnections\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-PrivateEndpointConnections\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_PrivateLinkResources_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-PrivateLinkResources\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-PrivateLinkResources\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_queries_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-queries\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-queries\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_recommendedElasticPools_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-recommendedElasticPools\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-recommendedElasticPools\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_recommendedElasticPoolsDecoupled_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-recommendedElasticPoolsDecoupled\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-recommendedElasticPoolsDecoupled\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_recoverableManagedDatabases_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-recoverableManagedDatabases\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-recoverableManagedDatabases\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_renameDatabase_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-renameDatabase\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-renameDatabase\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_replicationLinks_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-replicationLinks\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-replicationLinks\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_restorableDroppedManagedDatabases_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-restorableDroppedManagedDatabases\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-restorableDroppedManagedDatabases\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_restorePoints_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-restorePoints\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-restorePoints\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_SensitivityLabels_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-SensitivityLabels\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-SensitivityLabels\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_serverAutomaticTuning_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-serverAutomaticTuning\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-serverAutomaticTuning\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ServerAzureADAdministrators_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ServerAzureADAdministrators\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ServerAzureADAdministrators\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_serverCommunicationLinks_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-serverCommunicationLinks\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-serverCommunicationLinks\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_serverDnsAliases_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-serverDnsAliases\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-serverDnsAliases\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_serverKeys_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-serverKeys\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-serverKeys\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_serverOperations_2019_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-serverOperations\2019-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-serverOperations\2019-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_servers_2019_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-servers\2019-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-servers\2019-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_serverSecurityAlertPolicies_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-serverSecurityAlertPolicies\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-serverSecurityAlertPolicies\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_ServerVulnerabilityAssessments_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-ServerVulnerabilityAssessments\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-ServerVulnerabilityAssessments\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_serviceObjectives_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-serviceObjectives\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-serviceObjectives\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_shortTermRetentionPolicies_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-shortTermRetentionPolicies\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-shortTermRetentionPolicies\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_sql_core_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-sql.core\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-sql.core\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_syncAgents_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-syncAgents\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-syncAgents\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_syncGroups_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-syncGroups\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-syncGroups\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_syncMembers_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-syncMembers\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-syncMembers\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_tableAuditing_2014_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-tableAuditing\2014-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-tableAuditing\2014-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_TdeCertificates_2017_10_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-TdeCertificates\2017-10-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-TdeCertificates\2017-10-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_types_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-types\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-types\1.0");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_usages_2018_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-usages\2018-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-usages\2018-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_virtualclusters_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-virtualclusters\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-virtualclusters\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_virtualNetworkRules_2015_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-virtualNetworkRules\2015-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-virtualNetworkRules\2015-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_WorkloadClassifiers_2019_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-WorkloadClassifiers\2019-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-WorkloadClassifiers\2019-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sql_WorkloadGroups_2019_06_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sql-WorkloadGroups\2019-06-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sql-WorkloadGroups\2019-06-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_sqlvirtualmachine_sqlvm_2017_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\sqlvirtualmachine-sqlvm\2017-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\sqlvirtualmachine-sqlvm\2017-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_storage_2019_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\storage\2019-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\storage\2019-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_storage_blob_2019_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\storage-blob\2019-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\storage-blob\2019-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_storage_DataLakeStorage_2019_10_31()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\storage-DataLakeStorage\2019-10-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\storage-DataLakeStorage\2019-10-31");
 		}
 
 		[Fact]
 		public void Test_azure_com_storage_file_2019_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\storage-file\2019-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\storage-file\2019-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_storage_managementpolicy_2018_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\storage-managementpolicy\2018-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\storage-managementpolicy\2018-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_storagecache_2019_11_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\storagecache\2019-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\storagecache\2019-11-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_storageimportexport_2016_11_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\storageimportexport\2016-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\storageimportexport\2016-11-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_storagesync_2019_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\storagesync\2019-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\storagesync\2019-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_streamanalytics_functions_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\streamanalytics-functions\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\streamanalytics-functions\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_streamanalytics_inputs_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\streamanalytics-inputs\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\streamanalytics-inputs\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_streamanalytics_outputs_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\streamanalytics-outputs\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\streamanalytics-outputs\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_streamanalytics_streamingjobs_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\streamanalytics-streamingjobs\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\streamanalytics-streamingjobs\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_streamanalytics_subscriptions_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\streamanalytics-subscriptions\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\streamanalytics-subscriptions\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_streamanalytics_transformations_2016_03_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\streamanalytics-transformations\2016-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\streamanalytics-transformations\2016-03-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_subscription_operations_2018_03_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\subscription-operations\2018-03-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\subscription-operations\2018-03-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_subscription_subscriptionDefinitions_2017_11_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\subscription-subscriptionDefinitions\2017-11-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\subscription-subscriptionDefinitions\2017-11-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_support_2019_05_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\support\2019-05-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\support\2019-05-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_trafficmanager_2018_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\trafficmanager\2018-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\trafficmanager\2018-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_trafficmanager_trafficmanageranalytics_2017_09_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\trafficmanager-trafficmanageranalytics\2017-09-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\trafficmanager-trafficmanageranalytics\2017-09-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_visualstudio_Csm_2017_11_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\visualstudio-Csm\2017-11-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\visualstudio-Csm\2017-11-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_visualstudio_PipelineTemplates_2018_08_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\visualstudio-PipelineTemplates\2018-08-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\visualstudio-PipelineTemplates\2018-08-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_visualstudio_Projects_2018_08_01_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\visualstudio-Projects\2018-08-01-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\visualstudio-Projects\2018-08-01-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_vmwarecloudsimple_2019_04_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\vmwarecloudsimple\2019-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\vmwarecloudsimple\2019-04-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_AppServiceCertificateOrders_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-AppServiceCertificateOrders\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-AppServiceCertificateOrders\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_AppServiceEnvironments_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-AppServiceEnvironments\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-AppServiceEnvironments\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_AppServicePlans_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-AppServicePlans\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-AppServicePlans\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_CertificateRegistrationProvider_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-CertificateRegistrationProvider\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-CertificateRegistrationProvider\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_Certificates_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-Certificates\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-Certificates\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_CommonDefinitions_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-CommonDefinitions\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-CommonDefinitions\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_DeletedWebApps_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-DeletedWebApps\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-DeletedWebApps\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_Diagnostics_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-Diagnostics\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-Diagnostics\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_DomainRegistrationProvider_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-DomainRegistrationProvider\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-DomainRegistrationProvider\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_Domains_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-Domains\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-Domains\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_Provider_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-Provider\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-Provider\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_Recommendations_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-Recommendations\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-Recommendations\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_ResourceHealthMetadata_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-ResourceHealthMetadata\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-ResourceHealthMetadata\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_ResourceProvider_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-ResourceProvider\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-ResourceProvider\2019-08-01");
 		}
 
 		//[Fact]
 		//public void Test_azure_com_web_service_2015_08_01() Generic?
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-service\2015-08-01");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-service\2015-08-01");
 		//}
 
 
@@ -1550,31 +1550,31 @@ namespace SwagTests
 		[Fact]
 		public void Test_azure_com_web_TopLevelDomains_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-TopLevelDomains\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-TopLevelDomains\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_web_WebApps_2019_08_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\web-WebApps\2019-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\web-WebApps\2019-08-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_windowsesu_2019_09_16_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\windowsesu\2019-09-16-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\windowsesu\2019-09-16-preview");
 		}
 
 		[Fact]
 		public void Test_azure_com_windowsiot_WindowsIotServices_2019_06_01()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\windowsiot-WindowsIotServices\2019-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\windowsiot-WindowsIotServices\2019-06-01");
 		}
 
 		[Fact]
 		public void Test_azure_com_workloadmonitor_Microsoft_WorkloadMonitor_2018_08_31_preview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\azure.com\workloadmonitor-Microsoft.WorkloadMonitor\2018-08-31-preview");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\azure.com\workloadmonitor-Microsoft.WorkloadMonitor\2018-08-31-preview");
 		}
 
 	}

--- a/Tests/CsSwagger2Tests/ODMiscTests.cs
+++ b/Tests/CsSwagger2Tests/ODMiscTests.cs
@@ -15,374 +15,374 @@ namespace SwagTests
 		[Fact]
 		public void Test_bandsintown_com_3_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\bandsintown.com\3.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\bandsintown.com\3.0.0");
 		}
 
 		[Fact]
 		public void Test_bbc_co_uk_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\bbc.co.uk\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\bbc.co.uk\1.0.0");
 		}
 
 		[Fact]
 		public void Test_etmdb_com_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\etmdb.com\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\etmdb.com\1.0.0");
 		}
 
 		[Fact]
 		public void Test_europeana_eu_2_3_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\europeana.eu\2.3.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\europeana.eu\2.3.0");
 		}
 
 		[Fact]
 		public void Test_evemarketer_com_1_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\evemarketer.com\1.0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\evemarketer.com\1.0.1");
 		}
 
 		//[Fact]
 		//public void Test_github_com_v3() it has multiple parameters sharing the same name though in path and query, however, the url template defines one.
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\github.com\v3", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\github.com\v3", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		//[Fact]
 		//public void Test_gitlab_com_v3() it has properties with question mask as suffix
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\gitlab.com\v3");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\gitlab.com\v3");
 		//}
 
 		[Fact]
 		public void Test_globalwinescore_com_8234aab51481d37a30757d925b7f4221a659427e()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\globalwinescore.com\8234aab51481d37a30757d925b7f4221a659427e");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\globalwinescore.com\8234aab51481d37a30757d925b7f4221a659427e");
 		}
 
 		[Fact]
 		public void Test_graphhopper_com_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\graphhopper.com\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\graphhopper.com\1.0");
 		}
 
 		[Fact]
 		public void Test_greenpeace_org_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\greenpeace.org\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\greenpeace.org\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_gsa_gov_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\gsa.gov\0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\gsa.gov\0.1");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_AutoSuggest_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-AutoSuggest\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-AutoSuggest\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_ComputerVision_2_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-ComputerVision\2.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-ComputerVision\2.1");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_CustomImageSearch_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-CustomImageSearch\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-CustomImageSearch\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_CustomSearch_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-CustomSearch\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-CustomSearch\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_EntitySearch_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-EntitySearch\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-EntitySearch\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_ImageSearch_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-ImageSearch\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-ImageSearch\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_LocalSearch_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-LocalSearch\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-LocalSearch\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_NewsSearch_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-NewsSearch\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-NewsSearch\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_Ocr_2_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-Ocr\2.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-Ocr\2.1");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_Prediction_1_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-Prediction\1.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-Prediction\1.1");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_Prediction_3_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-Prediction\3.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-Prediction\3.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_SpellCheck_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-SpellCheck\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-SpellCheck\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_Training_3_2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-Training\3.2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-Training\3.2");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_VideoSearch_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-VideoSearch\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-VideoSearch\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_VisualSearch_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-VisualSearch\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-VisualSearch\1.0");
 		}
 
 		[Fact]
 		public void Test_microsoft_com_cognitiveservices_WebSearch_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\cognitiveservices-WebSearch\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\microsoft.com\cognitiveservices-WebSearch\1.0");
 		}
 
 
 		[Fact]
 		public void Test_sportsdata_io_cbb_v3_scores_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\cbb-v3-scores\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\cbb-v3-scores\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_cbb_v3_stats_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\cbb-v3-stats\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\cbb-v3-stats\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_cfb_v3_scores_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\cfb-v3-scores\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\cfb-v3-scores\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_csgo_v3_scores_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\csgo-v3-scores\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\csgo-v3-scores\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_csgo_v3_stats_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\csgo-v3-stats\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\csgo-v3-stats\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_golf_v2_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\golf-v2\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\golf-v2\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_lol_v3_projections_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\lol-v3-projections\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\lol-v3-projections\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_lol_v3_scores_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\lol-v3-scores\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\lol-v3-scores\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_lol_v3_stats_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\lol-v3-stats\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\lol-v3-stats\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_mlb_v3_play_by_play_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\mlb-v3-play-by-play\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\mlb-v3-play-by-play\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_mlb_v3_projections_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\mlb-v3-projections\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\mlb-v3-projections\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_mlb_v3_rotoballer_articles_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\mlb-v3-rotoballer-articles\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\mlb-v3-rotoballer-articles\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_mlb_v3_rotoballer_premium_news_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\mlb-v3-rotoballer-premium-news\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\mlb-v3-rotoballer-premium-news\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_mlb_v3_scores_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\mlb-v3-scores\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\mlb-v3-scores\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_mlb_v3_stats_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\mlb-v3-stats\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\mlb-v3-stats\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nascar_v2_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nascar-v2\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nascar-v2\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nba_v3_play_by_play_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nba-v3-play-by-play\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nba-v3-play-by-play\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nba_v3_projections_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nba-v3-projections\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nba-v3-projections\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nba_v3_rotoballer_articles_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nba-v3-rotoballer-articles\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nba-v3-rotoballer-articles\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nba_v3_rotoballer_premium_news_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nba-v3-rotoballer-premium-news\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nba-v3-rotoballer-premium-news\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nba_v3_scores_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nba-v3-scores\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nba-v3-scores\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nba_v3_stats_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nba-v3-stats\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nba-v3-stats\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nfl_v3_play_by_play_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nfl-v3-play-by-play\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nfl-v3-play-by-play\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nfl_v3_projections_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nfl-v3-projections\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nfl-v3-projections\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nfl_v3_rotoballer_articles_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nfl-v3-rotoballer-articles\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nfl-v3-rotoballer-articles\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nfl_v3_rotoballer_premium_news_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nfl-v3-rotoballer-premium-news\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nfl-v3-rotoballer-premium-news\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nfl_v3_scores_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nfl-v3-scores\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nfl-v3-scores\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nfl_v3_stats_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nfl-v3-stats\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nfl-v3-stats\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nhl_v3_play_by_play_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nhl-v3-play-by-play\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nhl-v3-play-by-play\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nhl_v3_projections_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nhl-v3-projections\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nhl-v3-projections\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nhl_v3_scores_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nhl-v3-scores\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nhl-v3-scores\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_nhl_v3_stats_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\nhl-v3-stats\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\nhl-v3-stats\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_soccer_v3_projections_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\soccer-v3-projections\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\soccer-v3-projections\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_soccer_v3_scores_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\soccer-v3-scores\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\soccer-v3-scores\1.0");
 		}
 
 		[Fact]
 		public void Test_sportsdata_io_soccer_v3_stats_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\sportsdata.io\soccer-v3-stats\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\sportsdata.io\soccer-v3-stats\1.0");
 		}
 
 
@@ -390,181 +390,181 @@ namespace SwagTests
 		[Fact]
 		public void Test_spotify_com_v1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\spotify.com\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\spotify.com\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_squareup_com_2_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\squareup.com\2.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\squareup.com\2.0");
 		}
 
 		[Fact]
 		public void Test_staging_ecotaco_com_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\staging-ecotaco.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\staging-ecotaco.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_statsocial_com_1_0_0() very strange design overall
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\statsocial.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\statsocial.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		//[Fact]
 		//public void Test_stoplight_io_api_v1() strange design with empty property name
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\stoplight.io\api-v1");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\stoplight.io\api-v1");
 		//}
 
 		//[Fact]
 		//public void Test_storecove_com_2_0_1() strange casual enum design in paymentMeansCode with empty enum member anem. NSwag translate it to 'Empty". I am not sure if I should support such design?
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\storecove.com\2.0.1");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\storecove.com\2.0.1");
 		//}
 
 		[Fact]
 		public void Test_stormglass_io_1_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\stormglass.io\1.0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\stormglass.io\1.0.1");
 		}
 
 		//[Fact]
 		//public void Test_stripe_com_2019_12_03()
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\stripe.com\2019-12-03");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\stripe.com\2019-12-03");
 		//}
 
 		[Fact]
 		public void Test_surrey_ca_open511_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\surrey.ca\open511\0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\surrey.ca\open511\0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_surrey_ca_trafficloops_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\surrey.ca\trafficloops\0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\surrey.ca\trafficloops\0.1");
 		}
 
 		[Fact]
 		public void Test_swagger_io_generator_2_4_11()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\swagger.io\generator\2.4.11");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\swagger.io\generator\2.4.11");
 		}
 
 		[Fact]
 		public void Test_swaggerhub_com_1_0_47()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\swaggerhub.com\1.0.47");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\swaggerhub.com\1.0.47");
 		}
 
 		[Fact]
 		public void Test_synq_fm_1_9_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\synq.fm\1.9.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\synq.fm\1.9.1");
 		}
 
 		//[Fact]
 		//public void Test_taggun_io_1_2_221() strange Model%203
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\taggun.io\1.2.221");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\taggun.io\1.2.221");
 		//}
 
 		[Fact]
 		public void Test_taxamo_com_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\taxamo.com\1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\taxamo.com\1");
 		}
 
 		[Fact]
 		public void Test_taxrates_io_3_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\taxrates.io\3.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\taxrates.io\3.0");
 		}
 
 		[Fact]
 		public void Test_text2data_org_v3_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\text2data.org\v3.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\text2data.org\v3.1");
 		}
 
 		//[Fact]
 		//public void Test_tfl_gov_uk_v1() it seems /StopPoint/Search has a duplicate : /StopPoint/Search/{query}
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tfl.gov.uk\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tfl.gov.uk\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_thenounproject_com_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\thenounproject.com\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\thenounproject.com\1.0.0");
 		}
 
 		[Fact]
 		public void Test_thesmsworks_co_uk_1_3_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\thesmsworks.co.uk\1.3.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\thesmsworks.co.uk\1.3.0");
 		}
 
 		[Fact]
 		public void Test_thetvdb_com_2_2_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\thetvdb.com\2.2.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\thetvdb.com\2.2.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_tinyuid_com_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tinyuid.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tinyuid.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_traccar_org_4_6()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\traccar.org\4.6", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\traccar.org\4.6", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_tradematic_com_1_0_2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tradematic.com\1.0.2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tradematic.com\1.0.2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_transavia_com_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\transavia.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\transavia.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_transitfeeds_com_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\transitfeeds.com\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\transitfeeds.com\1.0.0");
 		}
 
 		[Fact]
 		public void Test_trashnothing_com_1_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\trashnothing.com\1.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\trashnothing.com\1.1");
 		}
 
 		//[Fact]
 		//public void Test_trello_com_1_0() prefs_background and prefs/background in Boards, not looking good
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\trello.com\1.0");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\trello.com\1.0");
 		//}
 
 		//[Fact]
 		//public void Test_turbinelabs_io_1_0() poor inheritence design -- Domain : DomainCreate
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\turbinelabs.io\1.0");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\turbinelabs.io\1.0");
 		//}
 
 		[Fact]
 		public void Test_tvmaze_com_1_0()//to be resolved
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tvmaze.com\1.0", new Settings()
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tvmaze.com\1.0", new Settings()
 			{
 				ClientNamespace = "MyNS",
 				ContainerClassName = "Misc",
@@ -582,373 +582,373 @@ namespace SwagTests
 		[Fact]
 		public void Test_twilio_com_2010_04_01() //pretty complex path and query
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\twilio.com\2010-04-01", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\twilio.com\2010-04-01", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_twinehealth_com_v7_78_1() [] reserved characters as part of the parameter names in http query?  https://tools.ietf.org/html/rfc3986
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\twinehealth.com\v7.78.1");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\twinehealth.com\v7.78.1");
 		//}
 
 		[Fact]
 		public void Test_twitter_com_legacy_1_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\twitter.com\legacy\1.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\twitter.com\legacy\1.1");
 		}
 
 		//[Fact]
 		//public void Test_tyk_com_1_9() casual enum contains empty member
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tyk.com\1.9", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tyk.com\1.9", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_uebermaps_com_2_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\uebermaps.com\2.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\uebermaps.com\2.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_vatapi_com_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vatapi.com\1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vatapi.com\1");
 		}
 
 		[Fact]
 		public void Test_versioneye_com_2_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\versioneye.com\2.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\versioneye.com\2.0");
 		}
 
 		[Fact]
 		public void Test_vestorly_com_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vestorly.com\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vestorly.com\1.0.0");
 		}
 
 		//[Fact]
 		//public void Test_victorops_com_0_0_3() using what older than Swagger 2.0?
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\victorops.com\0.0.3", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\victorops.com\0.0.3", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_visagecloud_com_1_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\visagecloud.com\1.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\visagecloud.com\1.1");
 		}
 
 		[Fact]
 		public void Test_visiblethread_com_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\visiblethread.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\visiblethread.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_vocadb_net_v1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vocadb.net\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vocadb.net\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_voodoomfg_com_2_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\voodoomfg.com\2.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\voodoomfg.com\2.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_waag_org_v1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\waag.org\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\waag.org\v1");
 		}
 
 		[Fact]
 		public void Test_walmart_com_inventory_3_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\walmart.com\inventory\3.0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\walmart.com\inventory\3.0.1");
 		}
 
 		[Fact]
 		public void Test_walmart_com_item_3_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\walmart.com\item\3.0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\walmart.com\item\3.0.1");
 		}
 
 		[Fact]
 		public void Test_walmart_com_order_3_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\walmart.com\order\3.0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\walmart.com\order\3.0.1");
 		}
 
 		[Fact]
 		public void Test_walmart_com_price_3_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\walmart.com\price\3.0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\walmart.com\price\3.0.1");
 		}
 
 		//[Fact]
 		//public void Test_warwick_ac_uk_enterobase_v2_0()// having parameter schema in path and query of api/v2.0/{database}/{scheme}/loci looks ood. NSwag renames them to schemaQuery and schemaPath. I am not sure if I should tolerate such bad design of Swagger definition.
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\warwick.ac.uk\enterobase\v2.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\warwick.ac.uk\enterobase\v2.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		//[Fact]
 		//public void Test_watchful_li_1_0_0() // casual enum contains empty member
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\watchful.li\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\watchful.li\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_waterlinked_com_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\waterlinked.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\waterlinked.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_wavecell_com_v1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wavecell.com\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wavecell.com\v1");
 		}
 
 		[Fact]
 		public void Test_wealthport_com_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wealthport.com\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wealthport.com\1.0");
 		}
 
 		//[Fact]
 		//public void Test_weatherbit_io_2_0_0() the definitions for parameters mess up path and query. bulk/history/daily ...
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\weatherbit.io\2.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\weatherbit.io\2.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_weber_gesamtausgabe_de_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\weber-gesamtausgabe.de\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\weber-gesamtausgabe.de\1.0.0");
 		}
 
 		[Fact]
 		public void Test_wedpax_com_v1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wedpax.com\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wedpax.com\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_whapi_com_accounts_2_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\whapi.com\accounts\2.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\whapi.com\accounts\2.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_whapi_com_bets_2_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\whapi.com\bets\2.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\whapi.com\bets\2.0.0");
 		}
 
 		[Fact]
 		public void Test_whapi_com_locations_2_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\whapi.com\locations\2.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\whapi.com\locations\2.0");
 		}
 
 		[Fact]
 		public void Test_whapi_com_numbers_2_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\whapi.com\numbers\2.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\whapi.com\numbers\2.0");
 		}
 
 		[Fact]
 		public void Test_whapi_com_sessions_2_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\whapi.com\sessions\2.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\whapi.com\sessions\2.0.0");
 		}
 
 		[Fact]
 		public void Test_whapi_com_sportsdata_2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\whapi.com\sportsdata\2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\whapi.com\sportsdata\2");
 		}
 
 		[Fact]
 		public void Test_who_hosts_this_com_0_0_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\who-hosts-this.com\0.0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\who-hosts-this.com\0.0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_wikimedia_org_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wikimedia.org\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wikimedia.org\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_windows_net_batch_BatchService_2015_12_01_2_2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\batch-BatchService\2015-12-01.2.2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\batch-BatchService\2015-12-01.2.2");
 		}
 
 		[Fact]
 		public void Test_windows_net_batch_BatchService_2016_02_01_3_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\batch-BatchService\2016-02-01.3.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\batch-BatchService\2016-02-01.3.0");
 		}
 
 		[Fact]
 		public void Test_windows_net_batch_BatchService_2016_07_01_3_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\batch-BatchService\2016-07-01.3.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\batch-BatchService\2016-07-01.3.1");
 		}
 
 		[Fact]
 		public void Test_windows_net_batch_BatchService_2017_01_01_4_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\batch-BatchService\2017-01-01.4.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\batch-BatchService\2017-01-01.4.0");
 		}
 
 		[Fact]
 		public void Test_windows_net_batch_BatchService_2017_05_01_5_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\batch-BatchService\2017-05-01.5.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\batch-BatchService\2017-05-01.5.0");
 		}
 
 		[Fact]
 		public void Test_windows_net_batch_BatchService_2017_06_01_5_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\batch-BatchService\2017-06-01.5.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\batch-BatchService\2017-06-01.5.1");
 		}
 
 		[Fact]
 		public void Test_windows_net_batch_BatchService_2017_09_01_6_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\batch-BatchService\2017-09-01.6.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\batch-BatchService\2017-09-01.6.0");
 		}
 
 		[Fact]
 		public void Test_windows_net_batch_BatchService_2018_03_01_6_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\batch-BatchService\2018-03-01.6.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\batch-BatchService\2018-03-01.6.1");
 		}
 
 		[Fact]
 		public void Test_windows_net_batch_BatchService_2018_08_01_7_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\batch-BatchService\2018-08-01.7.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\batch-BatchService\2018-08-01.7.0");
 		}
 
 		//[Fact]
 		//public void Test_windows_net_graphrbac_1_6() bool as enum
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\windows.net\graphrbac\1.6");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\windows.net\graphrbac\1.6");
 		//}
 
 		[Fact]
 		public void Test_winsms_co_za_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\winsms.co.za\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\winsms.co.za\1.0.0");
 		}
 
 		[Fact]
 		public void Test_wmata_com_bus_realtime_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wmata.com\bus-realtime\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wmata.com\bus-realtime\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_wmata_com_bus_route_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wmata.com\bus-route\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wmata.com\bus-route\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_wmata_com_incidents_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wmata.com\incidents\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wmata.com\incidents\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_wmata_com_rail_realtime_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wmata.com\rail-realtime\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wmata.com\rail-realtime\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_wmata_com_rail_station_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wmata.com\rail-station\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wmata.com\rail-station\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_wordassociations_net_1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wordassociations.net\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wordassociations.net\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_wordnik_com_4_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wordnik.com\4.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wordnik.com\4.0");
 		}
 
 		[Fact]
 		public void Test_wowza_com_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wowza.com\1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wowza.com\1");
 		}
 
 		[Fact]
 		public void Test_wso2apistore_com_transform_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wso2apistore.com\transform\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wso2apistore.com\transform\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_xero_com_2_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\xero.com\2.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\xero.com\2.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_youneedabudget_com_1_0_0() nswag crash too
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\youneedabudget.com\1.0.0");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\youneedabudget.com\1.0.0");
 		//}
 
 		[Fact]
 		public void Test_yunbi_com_v2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\yunbi.com\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\yunbi.com\v2");
 		}
 
 		[Fact]
 		public void Test_zalando_com_v1_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\zalando.com\v1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\zalando.com\v1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_zappiti_com_4_15_174()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\zappiti.com\4.15.174");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\zappiti.com\4.15.174");
 		}
 
 		[Fact]
 		public void Test_zenoti_com_1_0_0()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\zenoti.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\zenoti.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_zoom_us_2_0_0() // RegistrantStatus should have maxLength rather than maximum for the  array
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\zoom.us\2.0.0");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\zoom.us\2.0.0");
 		//}
 
 		[Fact]
 		public void Test_zoomconnect_com_1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\zoomconnect.com\1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\zoomconnect.com\1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 

--- a/Tests/GenerateCases/Program.cs
+++ b/Tests/GenerateCases/Program.cs
@@ -31,6 +31,12 @@ namespace GenerateCases
 		public void Test_{funcNameSuffix}()
 		{{
 			helper.GenerateFromOpenApiAndBuild(@""..\..\..\..\openapi-directory\APIs\{d}"");
+		}}
+
+		[Fact]
+		public void Test_{funcNameSuffix}_SystemTextJson()
+		{{
+			helper.GenerateFromOpenApiAndBuild(@""..\..\..\..\openapi-directory\APIs\{d}"", new Settings(){{UseSystemTextJson = true}});
 		}}";
 			}));
 		}

--- a/Tests/GenerateCases/Program.cs
+++ b/Tests/GenerateCases/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
@@ -9,7 +10,7 @@ namespace GenerateCases
 		static void Main(string[] args)
 		{
 			Console.WriteLine("Read a text file in args1 to generate cases into file in args2.");
-			if (args.Length <2)
+			if (args.Length < 2)
 			{
 				Console.WriteLine("Need a text file path and an output file path.");
 				return;
@@ -18,15 +19,18 @@ namespace GenerateCases
 			var filePath = args[0];
 			var outputPath = args[1];
 			var fileNames = File.ReadAllLines(filePath);
-			File.WriteAllLines(outputPath, fileNames.Select(d =>
+			//baseName is used to path manipulation from the arg1 file contents
+			var baseName = @"openapi-directory\APIs\";
+			var testFileNames = fileNames.Select(fileName => fileName[(fileName.IndexOf(baseName, StringComparison.InvariantCultureIgnoreCase) + baseName.Length)..]).ToList();
+
+			File.WriteAllLines(outputPath, testFileNames.Select(d =>
 			{
-				var prefix = @"C:\VSProjects\Study\openapi-directory\APIs\";
-				var funcNameSuffix = d.Remove(0, prefix.Length).Replace('.', '_').Replace('\\', '_').Replace('-', '_');
+				var funcNameSuffix = d.Replace('.', '_').Replace('\\', '_').Replace('-', '_');
 				return $@"
 		[Fact]
 		public void Test_{funcNameSuffix}()
 		{{
-			helper.GenerateFromOpenApiAndBuild(@""{d}"");
+			helper.GenerateFromOpenApiAndBuild(@""..\..\..\..\openapi-directory\APIs\{d}"");
 		}}";
 			}));
 		}

--- a/Tests/NG2Tests/OpenApiDirectoryAwsTests.cs
+++ b/Tests/NG2Tests/OpenApiDirectoryAwsTests.cs
@@ -15,661 +15,661 @@ namespace SwagTests
 		[Fact]
 		public void Test_accessanalyzer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\accessanalyzer\2019-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\accessanalyzer\2019-11-01");
 		}
 
 		[Fact]
 		public void Test_acm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\acm\2015-12-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\acm\2015-12-08");
 		}
 
 		[Fact]
 		public void Test_acmpca()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\acm-pca\2017-08-22");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\acm-pca\2017-08-22");
 		}
 
 		//[Fact]
 		//public void Test_alexaforbusiness()PhoneNumberType enum is password. Looking bad definition.
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\alexaforbusiness\2017-11-09");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\alexaforbusiness\2017-11-09");
 		//}
 
 		[Fact]
 		public void Test_amplify()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\amplify\2017-07-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\amplify\2017-07-25");
 		}
 
 		[Fact]
 		public void Test_apigatewayv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\apigatewayv2\2018-11-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\apigatewayv2\2018-11-29");
 		}
 
 		[Fact]
 		public void Test_apigatewaymanagementapi()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\apigatewaymanagementapi\2018-11-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\apigatewaymanagementapi\2018-11-29");
 		}
 
 		[Fact]
 		public void Test_appconfig()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\appconfig\2019-10-09");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\appconfig\2019-10-09");
 		}
 
 		[Fact]
 		public void Test_applicationautoscaling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\application-autoscaling\2016-02-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\application-autoscaling\2016-02-06");
 		}
 
 		[Fact]
 		public void Test_applicationinsights()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\application-insights\2018-11-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\application-insights\2018-11-25");
 		}
 
 		[Fact]
 		public void Test_appmesh()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\appmesh\2019-01-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\appmesh\2019-01-25");
 		}
 
 		[Fact]
 		public void Test_appstream()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\appstream\2016-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\appstream\2016-12-01");
 		}
 
 		[Fact]
 		public void Test_appsync()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\appsync\2017-07-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\appsync\2017-07-25");
 		}
 
 		[Fact]
 		public void Test_athena()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\athena\2017-05-18");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\athena\2017-05-18");
 		}
 
 		[Fact]
 		public void Test_autoscaling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\autoscaling\2011-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\autoscaling\2011-01-01");
 		}
 
 		[Fact]
 		public void Test_autoscalingplans()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\autoscaling-plans\2018-01-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\autoscaling-plans\2018-01-06");
 		}
 
 		[Fact]
 		public void Test_AWSMigrationHub()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\AWSMigrationHub\2017-05-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\AWSMigrationHub\2017-05-31");
 		}
 
 		[Fact]
 		public void Test_backup()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\backup\2018-11-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\backup\2018-11-15");
 		}
 
 		[Fact]
 		public void Test_batch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\batch\2016-08-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\batch\2016-08-10");
 		}
 
 		[Fact]
 		public void Test_budgets()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\budgets\2016-10-20");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\budgets\2016-10-20");
 		}
 
 		[Fact]
 		public void Test_ce()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ce\2017-10-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ce\2017-10-25");
 		}
 
 		[Fact]
 		public void Test_chime()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\chime\2018-05-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\chime\2018-05-01");
 		}
 
 		[Fact]
 		public void Test_cloud9()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloud9\2017-09-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloud9\2017-09-23");
 		}
 
 		[Fact]
 		public void Test_clouddirectory()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\clouddirectory\2017-01-11");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\clouddirectory\2017-01-11");
 		}
 
 		[Fact]
 		public void Test_cloudformation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudformation\2010-05-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudformation\2010-05-15");
 		}
 
 		[Fact]
 		public void Test_cloudfront()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudfront\2019-03-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudfront\2019-03-26");
 		}
 
 		[Fact]
 		public void Test_cloudhsmv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudhsmv2\2017-04-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudhsmv2\2017-04-28");
 		}
 
 		[Fact]
 		public void Test_cloudsearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudsearch\2013-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudsearch\2013-01-01");
 		}
 
 		[Fact]
 		public void Test_cloudsearchdomain()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudsearchdomain\2013-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudsearchdomain\2013-01-01");
 		}
 
 		[Fact]
 		public void Test_cloudtrail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cloudtrail\2013-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cloudtrail\2013-11-01");
 		}
 
 		[Fact]
 		public void Test_codebuild()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codebuild\2016-10-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codebuild\2016-10-06");
 		}
 
 		[Fact]
 		public void Test_codecommit()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codecommit\2015-04-13");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codecommit\2015-04-13");
 		}
 
 		[Fact]
 		public void Test_codedeploy()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codedeploy\2014-10-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codedeploy\2014-10-06");
 		}
 
 		[Fact]
 		public void Test_codegurureviewer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codeguru-reviewer\2019-09-19");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codeguru-reviewer\2019-09-19");
 		}
 
 		[Fact]
 		public void Test_codeguruprofiler()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codeguruprofiler\2019-07-18");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codeguruprofiler\2019-07-18");
 		}
 
 		[Fact]
 		public void Test_codepipeline()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codepipeline\2015-07-09");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codepipeline\2015-07-09");
 		}
 
 		[Fact]
 		public void Test_codestar()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codestar\2017-04-19");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codestar\2017-04-19");
 		}
 
 		[Fact]
 		public void Test_codestarconnections()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codestar-connections\2019-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codestar-connections\2019-12-01");
 		}
 
 		[Fact]
 		public void Test_codestarnotifications()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\codestar-notifications\2019-10-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\codestar-notifications\2019-10-15");
 		}
 
 		[Fact]
 		public void Test_cognitoidentity()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cognito-identity\2014-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cognito-identity\2014-06-30");
 		}
 
 		[Fact]
 		public void Test_cognitosync()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cognito-sync\2014-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cognito-sync\2014-06-30");
 		}
 
 		[Fact]
 		public void Test_cognitoidp()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cognito-idp\2016-04-18");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cognito-idp\2016-04-18");
 		}
 
 		[Fact]
 		public void Test_comprehend()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\comprehend\2017-11-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\comprehend\2017-11-27");
 		}
 
 		[Fact]
 		public void Test_comprehendmedical()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\comprehendmedical\2018-10-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\comprehendmedical\2018-10-30");
 		}
 
 		[Fact]
 		public void Test_computeoptimizer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\compute-optimizer\2019-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\compute-optimizer\2019-11-01");
 		}
 
 		[Fact]
 		public void Test_config()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\config\2014-11-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\config\2014-11-12");
 		}
 
 		[Fact]
 		public void Test_connect()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\connect\2017-08-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\connect\2017-08-08");
 		}
 
 		[Fact]
 		public void Test_connectparticipant()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\connectparticipant\2018-09-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\connectparticipant\2018-09-07");
 		}
 
 		[Fact]
 		public void Test_cur()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\cur\2017-01-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\cur\2017-01-06");
 		}
 
 		[Fact]
 		public void Test_dataexchange()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dataexchange\2017-07-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dataexchange\2017-07-25");
 		}
 
 		[Fact]
 		public void Test_datapipeline()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\datapipeline\2012-10-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\datapipeline\2012-10-29");
 		}
 
 		[Fact]
 		public void Test_datasync()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\datasync\2018-11-09");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\datasync\2018-11-09");
 		}
 
 		[Fact]
 		public void Test_dax()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dax\2017-04-19");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dax\2017-04-19");
 		}
 
 		[Fact]
 		public void Test_detective()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\detective\2018-10-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\detective\2018-10-26");
 		}
 
 		[Fact]
 		public void Test_devicefarm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\devicefarm\2015-06-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\devicefarm\2015-06-23");
 		}
 
 		[Fact]
 		public void Test_directconnect()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\directconnect\2012-10-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\directconnect\2012-10-25");
 		}
 
 		[Fact]
 		public void Test_discovery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\discovery\2015-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\discovery\2015-11-01");
 		}
 
 		[Fact]
 		public void Test_dlm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dlm\2018-01-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dlm\2018-01-12");
 		}
 
 		[Fact]
 		public void Test_dms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dms\2016-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dms\2016-01-01");
 		}
 
 		[Fact]
 		public void Test_docdb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\docdb\2014-10-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\docdb\2014-10-31");
 		}
 
 		[Fact]
 		public void Test_ds()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ds\2015-04-16");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ds\2015-04-16");
 		}
 
 		[Fact]
 		public void Test_dynamodb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\dynamodb\2012-08-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\dynamodb\2012-08-10");
 		}
 
 		[Fact]
 		public void Test_ebs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ebs\2019-11-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ebs\2019-11-02");
 		}
 
 		//[Fact]
 		//public void Test_ec2() I already have other test suites testing this, and compare source code.
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ec2\2016-11-15");
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ec2\2016-11-15");
 		//}
 
 		[Fact]
 		public void Test_ec2instanceconnect()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ec2-instance-connect\2018-04-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ec2-instance-connect\2018-04-02");
 		}
 
 		[Fact]
 		public void Test_ecr()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ecr\2015-09-21");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ecr\2015-09-21");
 		}
 
 		[Fact]
 		public void Test_ecs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ecs\2014-11-13");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ecs\2014-11-13");
 		}
 
 		[Fact]
 		public void Test_eks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\eks\2017-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\eks\2017-11-01");
 		}
 
 		[Fact]
 		public void Test_elasticinference()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elastic-inference\2017-07-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elastic-inference\2017-07-25");
 		}
 
 		[Fact]
 		public void Test_elasticache()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticache\2015-02-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticache\2015-02-02");
 		}
 
 		[Fact]
 		public void Test_elasticbeanstalk()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticbeanstalk\2010-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticbeanstalk\2010-12-01");
 		}
 
 		[Fact]
 		public void Test_elasticfilesystem()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticfilesystem\2015-02-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticfilesystem\2015-02-01");
 		}
 
 		[Fact]
 		public void Test_elasticloadbalancing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticloadbalancing\2012-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticloadbalancing\2012-06-01");
 		}
 
 		[Fact]
 		public void Test_elasticloadbalancingv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticloadbalancingv2\2015-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticloadbalancingv2\2015-12-01");
 		}
 
 		[Fact]
 		public void Test_elasticmapreduce()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elasticmapreduce\2009-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elasticmapreduce\2009-03-31");
 		}
 
 		[Fact]
 		public void Test_elastictranscoder()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\elastictranscoder\2012-09-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\elastictranscoder\2012-09-25");
 		}
 
 		[Fact]
 		public void Test_email()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\email\2010-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\email\2010-12-01");
 		}
 
 		[Fact]
 		public void Test_entitlementmarketplace()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\entitlement.marketplace\2017-01-11");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\entitlement.marketplace\2017-01-11");
 		}
 
 		[Fact]
 		public void Test_es()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\es\2015-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\es\2015-01-01");
 		}
 
 		[Fact]
 		public void Test_eventbridge()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\eventbridge\2015-10-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\eventbridge\2015-10-07");
 		}
 
 		[Fact]
 		public void Test_events()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\events\2015-10-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\events\2015-10-07");
 		}
 
 		[Fact]
 		public void Test_firehose()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\firehose\2015-08-04");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\firehose\2015-08-04");
 		}
 
 		[Fact]
 		public void Test_fms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\fms\2018-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\fms\2018-01-01");
 		}
 
 		[Fact]
 		public void Test_forecast()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\forecast\2018-06-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\forecast\2018-06-26");
 		}
 
 		[Fact]
 		public void Test_forecastquery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\forecastquery\2018-06-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\forecastquery\2018-06-26");
 		}
 
 		[Fact]
 		public void Test_frauddetector()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\frauddetector\2019-11-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\frauddetector\2019-11-15");
 		}
 
 		[Fact]
 		public void Test_fsx()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\fsx\2018-03-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\fsx\2018-03-01");
 		}
 
 		[Fact]
 		public void Test_gamelift()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\gamelift\2015-10-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\gamelift\2015-10-01");
 		}
 
 		[Fact]
 		public void Test_glacier()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\glacier\2012-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\glacier\2012-06-01");
 		}
 
 		[Fact]
 		public void Test_globalaccelerator()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\globalaccelerator\2018-08-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\globalaccelerator\2018-08-08");
 		}
 
 		[Fact]
 		public void Test_glue()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\glue\2017-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\glue\2017-03-31");
 		}
 
 		[Fact]
 		public void Test_greengrass()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\greengrass\2017-06-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\greengrass\2017-06-07");
 		}
 
 		[Fact]
 		public void Test_groundstation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\groundstation\2019-05-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\groundstation\2019-05-23");
 		}
 
 		[Fact]
 		public void Test_guardduty()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\guardduty\2017-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\guardduty\2017-11-28");
 		}
 
 		[Fact]
 		public void Test_health()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\health\2016-08-04");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\health\2016-08-04");
 		}
 
 		[Fact]
 		public void Test_iam()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iam\2010-05-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iam\2010-05-08");
 		}
 
 		[Fact]
 		public void Test_imagebuilder()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\imagebuilder\2019-12-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\imagebuilder\2019-12-02");
 		}
 
 		[Fact]
 		public void Test_importexport()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\importexport\2010-06-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\importexport\2010-06-01");
 		}
 
 		[Fact]
 		public void Test_inspector()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\inspector\2016-02-16");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\inspector\2016-02-16");
 		}
 
 		[Fact]
 		public void Test_iot()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot\2015-05-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot\2015-05-28");
 		}
 
 		[Fact]
 		public void Test_iotdata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot-data\2015-05-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot-data\2015-05-28");
 		}
 
 		[Fact]
 		public void Test_iotjobsdata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot-jobs-data\2017-09-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot-jobs-data\2017-09-29");
 		}
 
 		[Fact]
 		public void Test_iot1clickdevices()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot1click-devices\2018-05-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot1click-devices\2018-05-14");
 		}
 
 		[Fact]
 		public void Test_iot1clickprojects()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iot1click-projects\2018-05-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iot1click-projects\2018-05-14");
 		}
 
 		[Fact]
 		public void Test_iotanalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotanalytics\2017-11-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotanalytics\2017-11-27");
 		}
 
 		[Fact]
 		public void Test_iotevents()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotevents\2018-07-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotevents\2018-07-27");
 		}
 
 		[Fact]
 		public void Test_ioteventsdata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotevents-data\2018-10-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotevents-data\2018-10-23");
 		}
 
 		[Fact]
 		public void Test_iotsecuretunneling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotsecuretunneling\2018-10-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotsecuretunneling\2018-10-05");
 		}
 
 		[Fact]
 		public void Test_iotsitewise()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotsitewise\2019-12-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotsitewise\2019-12-02");
 		}
 
 		[Fact]
 		public void Test_iotthingsgraph()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\iotthingsgraph\2018-09-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\iotthingsgraph\2018-09-06");
 		}
 
 

--- a/Tests/NG2Tests/OpenApiDirectoryAwsTests2.cs
+++ b/Tests/NG2Tests/OpenApiDirectoryAwsTests2.cs
@@ -15,655 +15,655 @@ namespace SwagTests
 		[Fact]
 		public void Test_kafka()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kafka\2018-11-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kafka\2018-11-14");
 		}
 
 		[Fact]
 		public void Test_kendra()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kendra\2019-02-03");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kendra\2019-02-03");
 		}
 
 		[Fact]
 		public void Test_kinesis()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesis\2013-12-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesis\2013-12-02");
 		}
 
 		[Fact]
 		public void Test_kinesisvideoarchivedmedia()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesis-video-archived-media\2017-09-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesis-video-archived-media\2017-09-30");
 		}
 
 		[Fact]
 		public void Test_kinesisvideomedia()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesis-video-media\2017-09-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesis-video-media\2017-09-30");
 		}
 
 		[Fact]
 		public void Test_kinesisvideosignaling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesis-video-signaling\2019-12-04");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesis-video-signaling\2019-12-04");
 		}
 
 		[Fact]
 		public void Test_kinesisanalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesisanalytics\2015-08-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesisanalytics\2015-08-14");
 		}
 
 		[Fact]
 		public void Test_kinesisanalyticsv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesisanalyticsv2\2018-05-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesisanalyticsv2\2018-05-23");
 		}
 
 		[Fact]
 		public void Test_kinesisvideo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kinesisvideo\2017-09-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kinesisvideo\2017-09-30");
 		}
 
 		[Fact]
 		public void Test_kms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\kms\2014-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\kms\2014-11-01");
 		}
 
 		[Fact]
 		public void Test_lakeformation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\lakeformation\2017-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\lakeformation\2017-03-31");
 		}
 
 		[Fact]
 		public void Test_lambda()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\lambda\2015-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\lambda\2015-03-31");
 		}
 
 		[Fact]
 		public void Test_lexmodels()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\lex-models\2017-04-19");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\lex-models\2017-04-19");
 		}
 
 		[Fact]
 		public void Test_licensemanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\license-manager\2018-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\license-manager\2018-08-01");
 		}
 
 		[Fact]
 		public void Test_lightsail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\lightsail\2016-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\lightsail\2016-11-28");
 		}
 
 		[Fact]
 		public void Test_logs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\logs\2014-03-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\logs\2014-03-28");
 		}
 
 		[Fact]
 		public void Test_machinelearning()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\machinelearning\2014-12-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\machinelearning\2014-12-12");
 		}
 
 		[Fact]
 		public void Test_macie2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\macie2\2020-01-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\macie2\2020-01-01");
 		}
 
 		[Fact]
 		public void Test_managedblockchain()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\managedblockchain\2018-09-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\managedblockchain\2018-09-24");
 		}
 
 		[Fact]
 		public void Test_marketplacecatalog()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\marketplace-catalog\2018-09-17");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\marketplace-catalog\2018-09-17");
 		}
 
 		[Fact]
 		public void Test_marketplacecommerceanalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\marketplacecommerceanalytics\2015-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\marketplacecommerceanalytics\2015-07-01");
 		}
 
 		[Fact]
 		public void Test_mediaconnect()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediaconnect\2018-11-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediaconnect\2018-11-14");
 		}
 
 		[Fact]
 		public void Test_mediaconvert()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediaconvert\2017-08-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediaconvert\2017-08-29");
 		}
 
 		[Fact]
 		public void Test_medialive()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\medialive\2017-10-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\medialive\2017-10-14");
 		}
 
 		[Fact]
 		public void Test_mediapackage()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediapackage\2017-10-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediapackage\2017-10-12");
 		}
 
 		[Fact]
 		public void Test_mediapackagevod()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediapackage-vod\2018-11-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediapackage-vod\2018-11-07");
 		}
 
 		[Fact]
 		public void Test_mediastore()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediastore\2017-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediastore\2017-09-01");
 		}
 
 		[Fact]
 		public void Test_mediastoredata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediastore-data\2017-09-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediastore-data\2017-09-01");
 		}
 
 		[Fact]
 		public void Test_mediatailor()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mediatailor\2018-04-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mediatailor\2018-04-23");
 		}
 
 		[Fact]
 		public void Test_meteringmarketplace()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\meteringmarketplace\2016-01-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\meteringmarketplace\2016-01-14");
 		}
 
 		[Fact]
 		public void Test_migrationhubconfig()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\migrationhub-config\2019-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\migrationhub-config\2019-06-30");
 		}
 
 		[Fact]
 		public void Test_mobile()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mobile\2017-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mobile\2017-07-01");
 		}
 
 		[Fact]
 		public void Test_mobileanalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mobileanalytics\2014-06-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mobileanalytics\2014-06-05");
 		}
 
 		[Fact]
 		public void Test_monitoring()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\monitoring\2010-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\monitoring\2010-08-01");
 		}
 
 		[Fact]
 		public void Test_mq()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mq\2017-11-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mq\2017-11-27");
 		}
 
 		[Fact]
 		public void Test_mturkrequester()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\mturk-requester\2017-01-17");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\mturk-requester\2017-01-17");
 		}
 
 		[Fact]
 		public void Test_neptune()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\neptune\2014-10-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\neptune\2014-10-31");
 		}
 
 		[Fact]
 		public void Test_networkmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\networkmanager\2019-07-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\networkmanager\2019-07-05");
 		}
 
 		[Fact]
 		public void Test_opsworkscm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\opsworkscm\2016-11-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\opsworkscm\2016-11-01");
 		}
 
 		[Fact]
 		public void Test_organizations()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\organizations\2016-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\organizations\2016-11-28");
 		}
 
 		[Fact]
 		public void Test_outposts()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\outposts\2019-12-03");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\outposts\2019-12-03");
 		}
 
 		[Fact]
 		public void Test_personalize()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\personalize\2018-05-22");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\personalize\2018-05-22");
 		}
 
 		[Fact]
 		public void Test_personalizeevents()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\personalize-events\2018-03-22");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\personalize-events\2018-03-22");
 		}
 
 		[Fact]
 		public void Test_personalizeruntime()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\personalize-runtime\2018-05-22");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\personalize-runtime\2018-05-22");
 		}
 
 		[Fact]
 		public void Test_pi()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\pi\2018-02-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\pi\2018-02-27");
 		}
 
 		[Fact]
 		public void Test_pinpoint()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\pinpoint\2016-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\pinpoint\2016-12-01");
 		}
 
 		[Fact]
 		public void Test_pinpointemail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\pinpoint-email\2018-07-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\pinpoint-email\2018-07-26");
 		}
 
 		[Fact]
 		public void Test_polly()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\polly\2016-06-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\polly\2016-06-10");
 		}
 
 		[Fact]
 		public void Test_pricing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\pricing\2017-10-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\pricing\2017-10-15");
 		}
 
 		[Fact]
 		public void Test_qldb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\qldb\2019-01-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\qldb\2019-01-02");
 		}
 
 		[Fact]
 		public void Test_qldbsession()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\qldb-session\2019-07-11");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\qldb-session\2019-07-11");
 		}
 
 		[Fact]
 		public void Test_quicksight()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\quicksight\2018-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\quicksight\2018-04-01");
 		}
 
 		[Fact]
 		public void Test_ram()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ram\2018-01-04");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ram\2018-01-04");
 		}
 
 		[Fact]
 		public void Test_rds()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\rds\2014-10-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\rds\2014-10-31");
 		}
 
 		[Fact]
 		public void Test_rdsdata()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\rds-data\2018-08-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\rds-data\2018-08-01");
 		}
 
 		[Fact]
 		public void Test_redshift()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\redshift\2012-12-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\redshift\2012-12-01");
 		}
 
 		[Fact]
 		public void Test_rekognition()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\rekognition\2016-06-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\rekognition\2016-06-27");
 		}
 
 		[Fact]
 		public void Test_resourcegroups()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\resource-groups\2017-11-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\resource-groups\2017-11-27");
 		}
 
 		[Fact]
 		public void Test_resourcegroupstaggingapi()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\resourcegroupstaggingapi\2017-01-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\resourcegroupstaggingapi\2017-01-26");
 		}
 
 		[Fact]
 		public void Test_robomaker()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\robomaker\2018-06-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\robomaker\2018-06-29");
 		}
 
 		[Fact]
 		public void Test_route53()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\route53\2013-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\route53\2013-04-01");
 		}
 
 		[Fact]
 		public void Test_route53domains()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\route53domains\2014-05-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\route53domains\2014-05-15");
 		}
 
 		[Fact]
 		public void Test_route53resolver()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\route53resolver\2018-04-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\route53resolver\2018-04-01");
 		}
 
 		[Fact]
 		public void Test_runtimelex()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\runtime.lex\2016-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\runtime.lex\2016-11-28");
 		}
 
 		[Fact]
 		public void Test_runtimesagemaker()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\runtime.sagemaker\2017-05-13");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\runtime.sagemaker\2017-05-13");
 		}
 
 		//[Fact]
 		//public void Test_s3() bool enum?
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\s3\2006-03-01");
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\s3\2006-03-01");
 		//}
 
 		[Fact]
 		public void Test_s3control()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\s3control\2018-08-20");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\s3control\2018-08-20");
 		}
 
 		[Fact]
 		public void Test_sagemaker()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sagemaker\2017-07-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sagemaker\2017-07-24");
 		}
 
 		[Fact]
 		public void Test_sagemakera2iruntime()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sagemaker-a2i-runtime\2019-11-07");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sagemaker-a2i-runtime\2019-11-07");
 		}
 
 		[Fact]
 		public void Test_savingsplans()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\savingsplans\2019-06-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\savingsplans\2019-06-28");
 		}
 
 		[Fact]
 		public void Test_schemas()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\schemas\2019-12-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\schemas\2019-12-02");
 		}
 
 		[Fact]
 		public void Test_sdb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sdb\2009-04-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sdb\2009-04-15");
 		}
 
 		[Fact]
 		public void Test_secretsmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\secretsmanager\2017-10-17");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\secretsmanager\2017-10-17");
 		}
 
 		[Fact]
 		public void Test_securityhub()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\securityhub\2018-10-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\securityhub\2018-10-26");
 		}
 
 		[Fact]
 		public void Test_serverlessrepo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\serverlessrepo\2017-09-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\serverlessrepo\2017-09-08");
 		}
 
 		[Fact]
 		public void Test_servicequotas()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\service-quotas\2019-06-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\service-quotas\2019-06-24");
 		}
 
 		[Fact]
 		public void Test_servicecatalog()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\servicecatalog\2015-12-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\servicecatalog\2015-12-10");
 		}
 
 		[Fact]
 		public void Test_servicediscovery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\servicediscovery\2017-03-14");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\servicediscovery\2017-03-14");
 		}
 
 		[Fact]
 		public void Test_sesv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sesv2\2019-09-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sesv2\2019-09-27");
 		}
 
 		[Fact]
 		public void Test_shield()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\shield\2016-06-02");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\shield\2016-06-02");
 		}
 
 		[Fact]
 		public void Test_signer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\signer\2017-08-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\signer\2017-08-25");
 		}
 
 		[Fact]
 		public void Test_sms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sms\2016-10-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sms\2016-10-24");
 		}
 
 		[Fact]
 		public void Test_smsvoice()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sms-voice\2018-09-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sms-voice\2018-09-05");
 		}
 
 		[Fact]
 		public void Test_snowball()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\snowball\2016-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\snowball\2016-06-30");
 		}
 
 		[Fact]
 		public void Test_sns()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sns\2010-03-31");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sns\2010-03-31");
 		}
 
 		[Fact]
 		public void Test_sqs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sqs\2012-11-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sqs\2012-11-05");
 		}
 
 		[Fact]
 		public void Test_ssm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\ssm\2014-11-06");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\ssm\2014-11-06");
 		}
 
 		[Fact]
 		public void Test_sso()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sso\2019-06-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sso\2019-06-10");
 		}
 
 		[Fact]
 		public void Test_ssooidc()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sso-oidc\2019-06-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sso-oidc\2019-06-10");
 		}
 
 		[Fact]
 		public void Test_states()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\states\2016-11-23");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\states\2016-11-23");
 		}
 
 		[Fact]
 		public void Test_storagegateway()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\storagegateway\2013-06-30");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\storagegateway\2013-06-30");
 		}
 
 		[Fact]
 		public void Test_streamsdynamodb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\streams.dynamodb\2012-08-10");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\streams.dynamodb\2012-08-10");
 		}
 
 		[Fact]
 		public void Test_sts()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\sts\2011-06-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\sts\2011-06-15");
 		}
 
 		[Fact]
 		public void Test_support()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\support\2013-04-15");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\support\2013-04-15");
 		}
 
 		[Fact]
 		public void Test_swf()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\swf\2012-01-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\swf\2012-01-25");
 		}
 
 		[Fact]
 		public void Test_synthetics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\synthetics\2017-10-11");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\synthetics\2017-10-11");
 		}
 
 		[Fact]
 		public void Test_textract()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\textract\2018-06-27");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\textract\2018-06-27");
 		}
 
 		[Fact]
 		public void Test_transcribe()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\transcribe\2017-10-26");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\transcribe\2017-10-26");
 		}
 
 		[Fact]
 		public void Test_transfer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\transfer\2018-11-05");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\transfer\2018-11-05");
 		}
 
 		[Fact]
 		public void Test_translate()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\translate\2017-07-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\translate\2017-07-01");
 		}
 
 		[Fact]
 		public void Test_waf()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\waf\2015-08-24");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\waf\2015-08-24");
 		}
 
 		[Fact]
 		public void Test_wafregional()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\waf-regional\2016-11-28");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\waf-regional\2016-11-28");
 		}
 
 		[Fact]
 		public void Test_wafv2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\wafv2\2019-07-29");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\wafv2\2019-07-29");
 		}
 
 		[Fact]
 		public void Test_workdocs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\workdocs\2016-05-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\workdocs\2016-05-01");
 		}
 
 		[Fact]
 		public void Test_worklink()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\worklink\2018-09-25");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\worklink\2018-09-25");
 		}
 
 		[Fact]
 		public void Test_workmail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\workmail\2017-10-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\workmail\2017-10-01");
 		}
 
 		[Fact]
 		public void Test_workmailmessageflow()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\workmailmessageflow\2019-05-01");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\workmailmessageflow\2019-05-01");
 		}
 
 		[Fact]
 		public void Test_workspaces()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\workspaces\2015-04-08");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\workspaces\2015-04-08");
 		}
 
 		[Fact]
 		public void Test_xray()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\amazonaws.com\xray\2016-04-12");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\amazonaws.com\xray\2016-04-12");
 		}
 
 	}

--- a/Tests/NG2Tests/OpenApiDirectoryGoogleTests.cs
+++ b/Tests/NG2Tests/OpenApiDirectoryGoogleTests.cs
@@ -16,439 +16,439 @@ namespace NG2Tests
 		[Fact]
 		public void Test_driveactivity()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\driveactivity\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\driveactivity\v2");
 		}
 
 		[Fact]
 		public void Test_drive()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\drive\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\drive\v3");
 		}
 
 		[Fact]
 		public void Test_doubleclicksearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\doubleclicksearch\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\doubleclicksearch\v2");
 		}
 
 		[Fact]
 		public void Test_doubleclickbidmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\doubleclickbidmanager\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\doubleclickbidmanager\v1");
 		}
 
 		[Fact]
 		public void Test_domainsrdap()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\domainsrdap\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\domainsrdap\v1");
 		}
 
 		[Fact]
 		public void Test_docs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\docs\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\docs\v1");
 		}
 
 		[Fact]
 		public void Test_dns()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dns\v2beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dns\v2beta1");
 		}
 
 		[Fact]
 		public void Test_dlp()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dlp\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dlp\v2");
 		}
 
 		[Fact]
 		public void Test_discovery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\discovery\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\discovery\v1");
 		}
 
 		[Fact]
 		public void Test_digitalassetlinks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\digitalassetlinks\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\digitalassetlinks\v1");
 		}
 
 		[Fact]
 		public void Test_dfareporting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dfareporting\v3.3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dfareporting\v3.3");
 		}
 
 		[Fact]
 		public void Test_deploymentmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\deploymentmanager\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\deploymentmanager\v2");
 		}
 
 		[Fact]
 		public void Test_datastore()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\datastore\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\datastore\v1");
 		}
 
 		[Fact]
 		public void Test_dataproc()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dataproc\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dataproc\v1");
 		}
 
 		[Fact]
 		public void Test_datafusion()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\datafusion\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\datafusion\v1beta1");
 		}
 
 		[Fact]
 		public void Test_dataflow()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\dataflow\v1b3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\dataflow\v1b3");
 		}
 
 		[Fact]
 		public void Test_customsearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\customsearch\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\customsearch\v1");
 		}
 
 		[Fact]
 		public void Test_content()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\content\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\content\v2");
 		}
 
 		[Fact]
 		public void Test_containeranalysis()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\containeranalysis\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\containeranalysis\v1beta1");
 		}
 
 		[Fact]
 		public void Test_container()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\container\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\container\v1");
 		}
 
 		[Fact]
 		public void Test_compute()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\compute\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\compute\v1");
 		}
 
 		[Fact]
 		public void Test_composer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\composer\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\composer\v1");
 		}
 
 		[Fact]
 		public void Test_commentanalyzer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\commentanalyzer\v1alpha1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\commentanalyzer\v1alpha1");
 		}
 
 		[Fact]
 		public void Test_cloudtrace()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudtrace\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudtrace\v2");
 		}
 
 		[Fact]
 		public void Test_cloudtasks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudtasks\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudtasks\v2");
 		}
 
 		[Fact]
 		public void Test_cloudshell()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudshell\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudshell\v1");
 		}
 
 		[Fact]
 		public void Test_cloudsearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudsearch\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudsearch\v1");
 		}
 
 		[Fact]
 		public void Test_cloudscheduler()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudscheduler\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudscheduler\v1");
 		}
 
 		[Fact]
 		public void Test_cloudresourcemanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudresourcemanager\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudresourcemanager\v2");
 		}
 
 		[Fact]
 		public void Test_cloudprofiler()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudprofiler\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudprofiler\v2");
 		}
 
 		[Fact]
 		public void Test_cloudprivatecatalogproducer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudprivatecatalogproducer\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudprivatecatalogproducer\v1beta1");
 		}
 
 		[Fact]
 		public void Test_cloudprivatecatalog()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudprivatecatalog\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudprivatecatalog\v1beta1");
 		}
 
 		[Fact]
 		public void Test_cloudkms()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudkms\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudkms\v1");
 		}
 
 		[Fact]
 		public void Test_cloudiot()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudiot\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudiot\v1");
 		}
 
 		[Fact]
 		public void Test_cloudidentity()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudidentity\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudidentity\v1");
 		}
 
 		[Fact]
 		public void Test_cloudfunctions()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudfunctions\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudfunctions\v1");
 		}
 
 		[Fact]
 		public void Test_clouderrorreporting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\clouderrorreporting\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\clouderrorreporting\v1beta1");
 		}
 
 		[Fact]
 		public void Test_clouddebugger()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\clouddebugger\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\clouddebugger\v2");
 		}
 
 		[Fact]
 		public void Test_cloudbuild()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudbuild\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudbuild\v1");
 		}
 
 		[Fact]
 		public void Test_cloudbilling()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudbilling\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudbilling\v1");
 		}
 
 		[Fact]
 		public void Test_cloudasset()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\cloudasset\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\cloudasset\v1");
 		}
 
 		[Fact]
 		public void Test_classroom()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\classroom\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\classroom\v1");
 		}
 
 		[Fact]
 		public void Test_civicinfo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\civicinfo\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\civicinfo\v2");
 		}
 
 		[Fact]
 		public void Test_chat()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\chat\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\chat\v1");
 		}
 
 		[Fact]
 		public void Test_calendar()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\calendar\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\calendar\v3");
 		}
 
 		[Fact]
 		public void Test_books()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\books\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\books\v1");
 		}
 
 		[Fact]
 		public void Test_blogger()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\blogger\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\blogger\v3");
 		}
 
 		[Fact]
 		public void Test_binaryauthorization()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\binaryauthorization\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\binaryauthorization\v1");
 		}
 
 		[Fact]
 		public void Test_bigtableadmin()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigtableadmin\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigtableadmin\v2");
 		}
 
 		[Fact]
 		public void Test_bigqueryreservation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigqueryreservation\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigqueryreservation\v1");
 		}
 
 		[Fact]
 		public void Test_bigquerydatatransfer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigquerydatatransfer\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigquerydatatransfer\v1");
 		}
 
 		[Fact]
 		public void Test_bigqueryconnection()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigqueryconnection\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigqueryconnection\v1beta1");
 		}
 
 		[Fact]
 		public void Test_bigquery()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\bigquery\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\bigquery\v2");
 		}
 
 		[Fact]
 		public void Test_automl()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\automl\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\automl\v1beta1");
 		}
 
 		[Fact]
 		public void Test_appsactivity()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\appsactivity\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\appsactivity\v1");
 		}
 
 		[Fact]
 		public void Test_appengine()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\appengine\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\appengine\v1");
 		}
 
 		[Fact]
 		public void Test_androidpublisher()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\androidpublisher\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\androidpublisher\v3");
 		}
 
 		[Fact]
 		public void Test_androidmanagement()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\androidmanagement\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\androidmanagement\v1");
 		}
 
 		[Fact]
 		public void Test_androidenterprise()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\androidenterprise\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\androidenterprise\v1");
 		}
 
 		[Fact]
 		public void Test_androiddeviceprovisioning()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\androiddeviceprovisioning\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\androiddeviceprovisioning\v1");
 		}
 
 		[Fact]
 		public void Test_analyticsreporting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\analyticsreporting\v4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\analyticsreporting\v4");
 		}
 
 		[Fact]
 		public void Test_analytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\analytics\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\analytics\v3");
 		}
 
 		[Fact]
 		public void Test_alertcenter()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\alertcenter\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\alertcenter\v1beta1");
 		}
 
 		[Fact]
 		public void Test_adsensehost()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\adsensehost\v4.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\adsensehost\v4.1");
 		}
 
 		[Fact]
 		public void Test_adsense()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\adsense\v1.4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\adsense\v1.4");
 		}
 
 		[Fact]
 		public void Test_adminreports_v1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\admin\reports_v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\admin\reports_v1");
 		}
 
 		[Fact]
 		public void Test_admindatatransfer_v1()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\admin\datatransfer_v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\admin\datatransfer_v1");
 		}
 
 		[Fact]
 		public void Test_adexperiencereport()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\adexperiencereport\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\adexperiencereport\v1");
 		}
 
 		[Fact]
 		public void Test_adexchangebuyer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\adexchangebuyer\v1.4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\adexchangebuyer\v1.4");
 		}
 
 		[Fact]
 		public void Test_accesscontextmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\accesscontextmanager\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\accesscontextmanager\v1");
 		}
 
 		[Fact]
 		public void Test_accessapproval()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\accessapproval\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\accessapproval\v1beta1");
 		}
 
 		[Fact]
 		public void Test_acceleratedmobilepageurl()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\acceleratedmobilepageurl\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\acceleratedmobilepageurl\v1");
 		}
 
 		[Fact]
 		public void Test_abusiveexperiencereport()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\abusiveexperiencereport\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\abusiveexperiencereport\v1");
 		}
 
 	}

--- a/Tests/NG2Tests/OpenApiDirectoryGoogleTests2.cs
+++ b/Tests/NG2Tests/OpenApiDirectoryGoogleTests2.cs
@@ -15,499 +15,499 @@ namespace SwagTests
 		[Fact]
 		public void Test_youtubeAnalytics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\youtubeAnalytics\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\youtubeAnalytics\v2");
 		}
 
 		[Fact]
 		public void Test_youtubereporting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\youtubereporting\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\youtubereporting\v1");
 		}
 
 		[Fact]
 		public void Test_youtube()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\youtube\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\youtube\v3");
 		}
 
 		[Fact]
 		public void Test_websecurityscanner()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\websecurityscanner\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\websecurityscanner\v1");
 		}
 
 		[Fact]
 		public void Test_webmasters()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\webmasters\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\webmasters\v3");
 		}
 
 		[Fact]
 		public void Test_webfonts()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\webfonts\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\webfonts\v1");
 		}
 
 		[Fact]
 		public void Test_vision()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\vision\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\vision\v1");
 		}
 
 		[Fact]
 		public void Test_videointelligence()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\videointelligence\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\videointelligence\v1");
 		}
 
 		[Fact]
 		public void Test_verifiedaccess()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\verifiedaccess\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\verifiedaccess\v1");
 		}
 
 		[Fact]
 		public void Test_vault()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\vault\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\vault\v1");
 		}
 
 		[Fact]
 		public void Test_translate()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\translate\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\translate\v2");
 		}
 
 		[Fact]
 		public void Test_tpu()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\tpu\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\tpu\v1");
 		}
 
 		[Fact]
 		public void Test_texttospeech()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\texttospeech\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\texttospeech\v1");
 		}
 
 		[Fact]
 		public void Test_testing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\testing\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\testing\v1");
 		}
 
 		[Fact]
 		public void Test_tasks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\tasks\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\tasks\v1");
 		}
 
 		[Fact]
 		public void Test_tagmanager()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\tagmanager\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\tagmanager\v1");
 		}
 
 		[Fact]
 		public void Test_streetviewpublish()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\streetviewpublish\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\streetviewpublish\v1");
 		}
 
 		[Fact]
 		public void Test_storagetransfer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\storagetransfer\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\storagetransfer\v1");
 		}
 
 		[Fact]
 		public void Test_storage()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\storage\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\storage\v1");
 		}
 
 		[Fact]
 		public void Test_sqladmin()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\sqladmin\v1beta4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\sqladmin\v1beta4");
 		}
 
 		[Fact]
 		public void Test_speech()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\speech\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\speech\v1");
 		}
 
 		[Fact]
 		public void Test_spanner()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\spanner\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\spanner\v1");
 		}
 
 		[Fact]
 		public void Test_sourcerepo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\sourcerepo\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\sourcerepo\v1");
 		}
 
 		[Fact]
 		public void Test_slides()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\slides\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\slides\v1");
 		}
 
 		[Fact]
 		public void Test_siteVerification()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\siteVerification\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\siteVerification\v1");
 		}
 
 		[Fact]
 		public void Test_sheets()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\sheets\v4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\sheets\v4");
 		}
 
 		[Fact]
 		public void Test_serviceusage()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\serviceusage\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\serviceusage\v1");
 		}
 
 		[Fact]
 		public void Test_servicenetworking()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\servicenetworking\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\servicenetworking\v1");
 		}
 
 		[Fact]
 		public void Test_servicemanagement()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\servicemanagement\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\servicemanagement\v1");
 		}
 
 		[Fact]
 		public void Test_servicecontrol()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\servicecontrol\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\servicecontrol\v1");
 		}
 
 		[Fact]
 		public void Test_serviceconsumermanagement()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\serviceconsumermanagement\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\serviceconsumermanagement\v1");
 		}
 
 		[Fact]
 		public void Test_servicebroker()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\servicebroker\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\servicebroker\v1");
 		}
 
 		[Fact]
 		public void Test_securitycenter()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\securitycenter\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\securitycenter\v1");
 		}
 
 		[Fact]
 		public void Test_searchconsole()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\searchconsole\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\searchconsole\v1");
 		}
 
 		[Fact]
 		public void Test_script()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\script\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\script\v1");
 		}
 
 		[Fact]
 		public void Test_safebrowsing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\safebrowsing\v4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\safebrowsing\v4");
 		}
 
 		[Fact]
 		public void Test_runtimeconfig()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\runtimeconfig\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\runtimeconfig\v1");
 		}
 
 		[Fact]
 		public void Test_run()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\run\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\run\v1");
 		}
 
 		[Fact]
 		public void Test_reseller()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\reseller\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\reseller\v1");
 		}
 
 		[Fact]
 		public void Test_replicapool()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\replicapool\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\replicapool\v1beta1");
 		}
 
 		[Fact]
 		public void Test_remotebuildexecution()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\remotebuildexecution\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\remotebuildexecution\v1");
 		}
 
 		[Fact]
 		public void Test_redis()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\redis\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\redis\v1");
 		}
 
 		[Fact]
 		public void Test_recommender()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\recommender\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\recommender\v1beta1");
 		}
 
 		[Fact]
 		public void Test_pubsub()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\pubsub\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\pubsub\v1");
 		}
 
 		[Fact]
 		public void Test_proximitybeacon()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\proximitybeacon\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\proximitybeacon\v1beta1");
 		}
 
 		[Fact]
 		public void Test_poly()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\poly\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\poly\v1");
 		}
 
 		[Fact]
 		public void Test_policytroubleshooter()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\policytroubleshooter\v1beta");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\policytroubleshooter\v1beta");
 		}
 
 		[Fact]
 		public void Test_playcustomapp()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\playcustomapp\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\playcustomapp\v1");
 		}
 
 		[Fact]
 		public void Test_people()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\people\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\people\v1");
 		}
 
 		[Fact]
 		public void Test_pagespeedonline()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\pagespeedonline\v5");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\pagespeedonline\v5");
 		}
 
 		[Fact]
 		public void Test_oslogin()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\oslogin\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\oslogin\v1");
 		}
 
 		[Fact]
 		public void Test_oauth2()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\oauth2\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\oauth2\v2");
 		}
 
 		[Fact]
 		public void Test_monitoring()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\monitoring\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\monitoring\v3");
 		}
 
 		[Fact]
 		public void Test_mirror()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\mirror\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\mirror\v1");
 		}
 
 		[Fact]
 		public void Test_manufacturers()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\manufacturers\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\manufacturers\v1");
 		}
 
 		[Fact]
 		public void Test_logging()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\logging\v2");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\logging\v2");
 		}
 
 		[Fact]
 		public void Test_licensing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\licensing\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\licensing\v1");
 		}
 
 		[Fact]
 		public void Test_libraryagent()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\libraryagent\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\libraryagent\v1");
 		}
 
 		[Fact]
 		public void Test_language()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\language\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\language\v1");
 		}
 
 		//[Fact]
 		//public void Test_kgsearch() very short. And SearchResponse is having @context
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\kgsearch\v1");
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\googleapis.com\kgsearch\v1");
 		//}
 
 		[Fact]
 		public void Test_jobs()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\jobs\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\jobs\v3");
 		}
 
 		[Fact]
 		public void Test_indexing()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\indexing\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\indexing\v3");
 		}
 
 		[Fact]
 		public void Test_identitytoolkit()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\identitytoolkit\v3");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\identitytoolkit\v3");
 		}
 
 		[Fact]
 		public void Test_iap()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\iap\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\iap\v1");
 		}
 
 		[Fact]
 		public void Test_iamcredentials()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\iamcredentials\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\iamcredentials\v1");
 		}
 
 		[Fact]
 		public void Test_iam()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\iam\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\iam\v1");
 		}
 
 		[Fact]
 		public void Test_homegraph()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\homegraph\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\homegraph\v1");
 		}
 
 		[Fact]
 		public void Test_healthcare()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\healthcare\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\healthcare\v1beta1");
 		}
 
 		[Fact]
 		public void Test_groupssettings()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\groupssettings\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\groupssettings\v1");
 		}
 
 		[Fact]
 		public void Test_groupsmigration()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\groupsmigration\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\groupsmigration\v1");
 		}
 
 		[Fact]
 		public void Test_gmail()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\gmail\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\gmail\v1");
 		}
 
 		[Fact]
 		public void Test_genomics()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\genomics\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\genomics\v1");
 		}
 
 		[Fact]
 		public void Test_gamesManagement()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\gamesManagement\v1management");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\gamesManagement\v1management");
 		}
 
 		[Fact]
 		public void Test_gamesConfiguration()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\gamesConfiguration\v1configuration");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\gamesConfiguration\v1configuration");
 		}
 
 		[Fact]
 		public void Test_games()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\games\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\games\v1");
 		}
 
 		[Fact]
 		public void Test_fitness()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\fitness\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\fitness\v1");
 		}
 
 		[Fact]
 		public void Test_firestore()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\firestore\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\firestore\v1");
 		}
 
 		[Fact]
 		public void Test_firebaserules()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\firebaserules\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\firebaserules\v1");
 		}
 
 		[Fact]
 		public void Test_firebasehosting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\firebasehosting\v1beta1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\firebasehosting\v1beta1");
 		}
 
 		[Fact]
 		public void Test_firebasedynamiclinks()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\firebasedynamiclinks\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\firebasedynamiclinks\v1");
 		}
 
 		[Fact]
 		public void Test_file()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\file\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\file\v1");
 		}
 
 		[Fact]
 		public void Test_fcm()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\fcm\v1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\fcm\v1");
 		}
 
 		[Fact]
 		public void Test_factchecktools()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\googleapis.com\factchecktools\v1alpha1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\googleapis.com\factchecktools\v1alpha1");
 		}
 
 

--- a/Tests/NG2Tests/OpenApiDirectoryTests.cs
+++ b/Tests/NG2Tests/OpenApiDirectoryTests.cs
@@ -16,202 +16,202 @@ namespace SwagTests
 		[Fact]
 		public void Test_wheretocredit()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\wheretocredit.com\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\wheretocredit.com\1.0");
 		}
 
 		[Fact]
 		public void Test_vonagevgis()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vonage.com\vgis\1.0.1");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vonage.com\vgis\1.0.1");
 		}
 
 		[Fact]
 		public void Test_vonageuser()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vonage.com\user\1.11.8");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vonage.com\user\1.11.8");
 		}
 
 		[Fact]
 		public void Test_vonageaccount()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vonage.com\account\1.11.8");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vonage.com\account\1.11.8");
 		}
 
 
 		[Fact]
 		public void Test_vimeo()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\vimeo.com\3.4");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\vimeo.com\3.4");
 		}
 
 		//[Fact]System.ArgumentException : Not yet supported enumMember of Microsoft.OpenApi.Any.OpenApiBoolean with HideReplyByIdBodyHidden
 		//Enum with boolean in operation HideReplyById. Nswag could not either.
 		//public void Test_twitter()
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\twitter.com\labs\2.7");
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\twitter.com\labs\2.7");
 		//}
 
 		[Fact]
 		public void Test_tomtomsearch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tomtom.com\search\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tomtom.com\search\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_tomtomrouting()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tomtom.com\routing\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tomtom.com\routing\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_tomtommaps()//empty property 
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tomtom.com\maps\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tomtom.com\maps\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_tisane()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\tisane.ai\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\tisane.ai\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_stackexchange() has a array type member property: 'the id of the object (answer, comment, question, or user) the event describes'
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\stackexchange.com\2.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\stackexchange.com\2.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		//[Fact]
 		//public void Test_shutterstock()//has duplicate definitions of api calls.
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\shutterstock.com\1.0.16", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\shutterstock.com\1.0.16", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_ritekit()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ritekit.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ritekit.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_football()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\rapidapi.com\football-prediction\2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\rapidapi.com\football-prediction\2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_rebilly()
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\rebilly.com\2.1");wrong definitions with duplicated enum member voided in billingStatus.
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\rebilly.com\2.1");wrong definitions with duplicated enum member voided in billingStatus.
 		//}
 
 		[Fact]
 		public void Test_randommer()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\randommer.io\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\randommer.io\v1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_patientview()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\patientview.org\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\patientview.org\1.0");
 		}
 
 		[Fact]
 		public void Test_parliament()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\parliament.uk\search\Live");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\parliament.uk\search\Live");
 		}
 
 		[Fact]
 		public void Test_openlinksw()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\openlinksw.com\osdb\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\openlinksw.com\osdb\1.0.0");
 		}
 
 		[Fact]
 		public void Test_opendatanetwork()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\opendatanetwork.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\opendatanetwork.com\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_oceandrivers()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\oceandrivers.com\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\oceandrivers.com\1.0");
 		}
 
 		[Fact]
 		public void Test_nsidc()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\nsidc.org\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\nsidc.org\1.0.0");
 		}
 
 		//[Fact]
 		//public void Test_domainfinder()//empty property?
 		//{
-		//	helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\nic.at\domainfinder\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\nic.at\domainfinder\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_neowsapp()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\neowsapp.com\1.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\neowsapp.com\1.0");
 		}
 
 		[Fact]
 		public void Test_namsor()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\namsor.com\2.0.5");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\namsor.com\2.0.5");
 		}
 
 		[Fact]
 		public void Test_math()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\math.tools\1.5", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\math.tools\1.5", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_listennotes() //it has funky casual enum in operation, with type double and default value. Code generated won't pass compilation. Better not to tolerate such definitiohn.
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\listennotes.com\2.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\listennotes.com\2.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		//[Fact]
 		//public void Test_linode()// The Grant type has a casual enum definition with member null. OpenApi lib could not intepret it well
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\linode.com\4.5.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\linode.com\4.5.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 		[Fact]
 		public void Test_iptwist()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\iptwist.com\1.0.0");
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\iptwist.com\1.0.0");
 		}
 
 		[Fact]
 		public void Test_ipinfodb()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ipinfodb.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ipinfodb.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_mycru()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\mycru.io\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\mycru.io\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_mercure()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\mercure.local\0.3.2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\mercure.local\0.3.2", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_microsoftgraph()
 		//{
 		//	//ms graph yaml has some funky paths like /groups/{group-id}/calendar/calendarView/{event-id}/instances/{event-id}, duplicate parameters.
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\microsoft.com\graph\1.0.1", new Settings()
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\microsoft.com\graph\1.0.1", new Settings()
 		//	{
 		//		ClientNamespace = "MyNS",
 		//		//NamespaceInClassName = "microsoft.graph.",
@@ -231,67 +231,67 @@ namespace SwagTests
 		[Fact]
 		public void Test_ip2whois()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ip2whois.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ip2whois.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_ip2proxy()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ip2proxy.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ip2proxy.com\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_geolocation()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\ip2location.com\geolocation\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\ip2location.com\geolocation\1.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_convertcurrency()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\interzoid.com\convertcurrency\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\interzoid.com\convertcurrency\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_getaddressmatch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\interzoid.com\getaddressmatch\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\interzoid.com\getaddressmatch\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_getareacodefromnumber()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\interzoid.com\getareacodefromnumber\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\interzoid.com\getareacodefromnumber\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_getcitymatch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\interzoid.com\getcitymatch\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\interzoid.com\getcitymatch\1.0.0", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_hackathonwatch()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\hackathonwatch.com\0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\hackathonwatch.com\0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_bcdc()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\gov.bc.ca\bcdc\3.0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\gov.bc.ca\bcdc\3.0.1", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		[Fact]
 		public void Test_bcgnws()
 		{
-			helper.GenerateFromOpenApiAndBuild(@"C:\VSProjects\Study\openapi-directory\APIs\gov.bc.ca\bcgnws\3.x.x", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+			helper.GenerateFromOpenApiAndBuild(@"..\..\..\..\openapi-directory\APIs\gov.bc.ca\bcgnws\3.x.x", CodeGenSettings.WithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		}
 
 		//[Fact]
 		//public void Test_geocoder()has invalid url sites/{siteID}/subsites.{outputFormat} and sites/{siteID}.{outputFormat},  https://stackoverflow.com/questions/3856693/a-url-resource-that-is-a-dot-2e
 		//{
-		//	helper.GenerateAndAssert(@"C:\VSProjects\Study\openapi-directory\APIs\gov.bc.ca\geocoder\2.0.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
+		//	helper.GenerateAndAssert(@"..\..\..\..\openapi-directory\APIs\gov.bc.ca\geocoder\2.0.0", CodeGenSettings.SettingsWithActionNameStrategy(ActionNameStrategy.PathMethodQueryParameters));
 		//}
 
 


### PR DESCRIPTION
Change the strings containing tabs to use \t.
Add System.Text.Json support
Add new settings:

Use System.Text.Json instead of Newtonsoft.Json
public bool UseSystemTextJson { get; set; }

Generated data types will be decorated with JsonProperty with the PropertyName in C#.
public bool DecorateDataModelWithPropertyName { get; set; }

Disable property nullable by default. Set by the OpenApi v3 option nullable 
public bool DisableSystemNullableByDefault { get; set; }

Use T? instead of System.Nullable<T>. C# 8.0 feature
public bool UseCSharpNullable { get; set; }

Create the Model classes only
public bool GenerateModelsOnly { get; set; }

Create arrays as List<T>
public bool ArrayAsList { get; set; }

Create arrays as ICollection<T>
public bool ArrayAsICollection { get; set; }